### PR TITLE
Disables suicide verbs

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -19,6 +19,7 @@
 		if(mmi.brainmob)
 			mmi.brainmob.suiciding = suicide_state
 
+/* DISABLES SUICIDE VERBS
 /mob/living/carbon/human/verb/suicide()
 	set hidden = TRUE
 	if(!canSuicide())
@@ -217,6 +218,7 @@
 
 		death(FALSE)
 		ghostize(FALSE) // Disallows reentering body and disassociates mind
+*/
 
 /mob/living/proc/suicide_log()
 	log_message("committed suicide as [src.type]", LOG_ATTACK)


### PR DESCRIPTION
## About The Pull Request

Disables the suicide verbs.

## Why It's Good For The Game

They're made to be comedic events that encourage people to commit suicide. Not great for an RP server.

## Changelog
:cl:
del: Suicide verbs have been disabled.
/:cl: