### PR TITLE
Fixes hypo kits missing vials

### DIFF
--- a/starbloom_modules/hyposprays/code/hypospray_kits.dm
+++ b/starbloom_modules/hyposprays/code/hypospray_kits.dm
@@ -95,6 +95,9 @@
 	if(empty)
 		return
 	new /obj/item/hypospray/mkii(src)
+	new /obj/item/reagent_containers/glass/vial/small(src)
+	new /obj/item/reagent_containers/glass/vial/small(src)
+	new /obj/item/reagent_containers/glass/vial/small(src)
 
 /obj/item/storage/hypospraykit/cmo
 	name = "deluxe hypospray kit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hypo boxes used to be missing vials. Now they aren't.

## Why It's Good For The Game

catmin fix

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: hypo kits include vials
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
