### PR TITLE
GUNSEC Part 2 - Rifles

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -1,11 +1,32 @@
 // 7.62 (Nagant Rifle)
 
 /obj/item/ammo_casing/a762
-	name = "7.62 bullet casing"
+	name = "7.62 FMJ bullet casing"
 	desc = "A 7.62 bullet casing."
 	icon_state = "762-casing"
 	caliber = CALIBER_A762
 	projectile_type = /obj/projectile/bullet/a762
+
+/obj/item/ammo_casing/a762/ap
+	name = "7.62 AP bullet casing"
+	desc = "A 7.62 bullet casing. Contains armour-piercing rounds."
+	icon_state = "762-casing"
+	caliber = CALIBER_A762
+	projectile_type = /obj/projectile/bullet/a762/ap
+
+/obj/item/ammo_casing/a762/hp
+	name = "7.62 HP bullet casing"
+	desc = "A 7.62 bullet casing. Contains hollowpoint rounds."
+	icon_state = "762-casing"
+	caliber = CALIBER_A762
+	projectile_type = /obj/projectile/bullet/a762/hp
+
+/obj/item/ammo_casing/a762/i
+	name = "7.62 Incendiary bullet casing"
+	desc = "A 7.62 bullet casing. Contains incendiary rounds."
+	icon_state = "762-casing"
+	caliber = CALIBER_A762
+	projectile_type = /obj/projectile/bullet/a762/i
 
 /obj/item/ammo_casing/a762/enchanted
 	projectile_type = /obj/projectile/bullet/a762/enchanted
@@ -13,10 +34,28 @@
 // 5.56mm (M-90gl Carbine)
 
 /obj/item/ammo_casing/a556
-	name = "5.56mm bullet casing"
+	name = "5.56mm FMJ bullet casing"
 	desc = "A 5.56mm bullet casing."
 	caliber = CALIBER_A556
 	projectile_type = /obj/projectile/bullet/a556
+
+/obj/item/ammo_casing/a556/ap
+	name = "5.56mm AP bullet casing"
+	desc = "A 5.56mm bullet casing. Contains armour-piercing rounds."
+	caliber = CALIBER_A556
+	projectile_type = /obj/projectile/bullet/a556/ap
+
+/obj/item/ammo_casing/a556/hp
+	name = "5.56mm HP bullet casing"
+	desc = "A 5.56mm bullet casing. Contains hollowpoint rounds."
+	caliber = CALIBER_A556
+	projectile_type = /obj/projectile/bullet/a556/hp
+
+/obj/item/ammo_casing/a556/i
+	name = "5.56mm Incendiary bullet casing"
+	desc = "A 5.56mm bullet casing. Contains incendiary rounds."
+	caliber = CALIBER_A556
+	projectile_type = /obj/projectile/bullet/a556/i
 
 /obj/item/ammo_casing/a556/phasic
 	name = "5.56mm phasic bullet casing"

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -23,16 +23,26 @@
 	desc = "A .45 rubber bullet casing."
 	projectile_type = /obj/projectile/bullet/c45
 
+/obj/item/ammo_casing/c45/ap
+	name = ".45 AP bullet casing"
+	desc = "A .45 armour-piercing bullet casing."
+	projectile_type = /obj/projectile/bullet/c45/ap
+
+/obj/item/ammo_casing/c45/hp
+	name = ".45 HP casing"
+	desc = "A .45 hollowpoint casing."
+	projectile_type = /obj/projectile/bullet/c45/hp
+
+/obj/item/ammo_casing/c45/i
+	name = ".45 incendiary casing"
+	desc = "A .45 incendiary casing."
+	projectile_type = /obj/projectile/bullet/c45/i
+
 /obj/item/ammo_casing/c45/fmj
 	name = ".45 FMJ bullet casing"
 	desc = "A .45 FMJ bullet casing."
 	caliber = CALIBER_45
 	projectile_type = /obj/projectile/bullet/c45/fmj
-
-/obj/item/ammo_casing/c45/ap
-	name = ".45 armor-piercing bullet casing"
-	desc = "A .45 bullet casing."
-	projectile_type = /obj/projectile/bullet/c45/ap
 
 /obj/item/ammo_casing/c45/inc
 	name = ".45 incendiary bullet casing"

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -95,10 +95,34 @@
 	multiple_sprites = AMMO_BOX_PER_BULLET
 
 /obj/item/ammo_box/a762
-	name = "stripper clip (7.62mm)"
+	name = "stripper clip (7.62mm FMJ)"
 	desc = "A stripper clip."
 	icon_state = "762"
 	ammo_type = /obj/item/ammo_casing/a762
+	max_ammo = 5
+	multiple_sprites = AMMO_BOX_PER_BULLET
+
+/obj/item/ammo_box/a762/ap
+	name = "stripper clip (7.62mm AP)"
+	desc = "A stripper clip. Contains armour-piercing rounds."
+	icon_state = "762"
+	ammo_type = /obj/item/ammo_casing/a762/ap
+	max_ammo = 5
+	multiple_sprites = AMMO_BOX_PER_BULLET
+
+/obj/item/ammo_box/a762/hp
+	name = "stripper clip (7.62mm HP)"
+	desc = "A stripper clip. Contains hollowpoint rounds."
+	icon_state = "762"
+	ammo_type = /obj/item/ammo_casing/a762/hp
+	max_ammo = 5
+	multiple_sprites = AMMO_BOX_PER_BULLET
+
+/obj/item/ammo_box/a762/i
+	name = "stripper clip (7.62mm Incendiary)"
+	desc = "A stripper clip. Contains incendiary rounds."
+	icon_state = "762"
+	ammo_type = /obj/item/ammo_casing/a762/i
 	max_ammo = 5
 	multiple_sprites = AMMO_BOX_PER_BULLET
 

--- a/code/modules/projectiles/boxes_magazines/external/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rifle.dm
@@ -11,9 +11,33 @@
 	icon_state = "[base_icon_state]-[ammo_count() ? "8" : "0"]"
 
 /obj/item/ammo_box/magazine/m556
-	name = "toploader magazine (5.56mm)"
+	name = "toploader magazine (5.56mm FMJ)"
 	icon_state = "5.56m"
 	ammo_type = /obj/item/ammo_casing/a556
+	caliber = CALIBER_A556
+	max_ammo = 30
+	multiple_sprites = AMMO_BOX_FULL_EMPTY
+
+/obj/item/ammo_box/magazine/m556/ap
+	name = "toploader magazine (5.56mm AP)"
+	icon_state = "5.56m"
+	ammo_type = /obj/item/ammo_casing/a556/ap
+	caliber = CALIBER_A556
+	max_ammo = 30
+	multiple_sprites = AMMO_BOX_FULL_EMPTY
+
+/obj/item/ammo_box/magazine/m556/hp
+	name = "toploader magazine (5.56mm HP)"
+	icon_state = "5.56m"
+	ammo_type = /obj/item/ammo_casing/a556/hp
+	caliber = CALIBER_A556
+	max_ammo = 30
+	multiple_sprites = AMMO_BOX_FULL_EMPTY
+
+/obj/item/ammo_box/magazine/m556/i
+	name = "toploader magazine (5.56mm Incendiary)"
+	icon_state = "5.56m"
+	ammo_type = /obj/item/ammo_casing/a556/i
 	caliber = CALIBER_A556
 	max_ammo = 30
 	multiple_sprites = AMMO_BOX_FULL_EMPTY

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -75,10 +75,10 @@
 	ammo_type = /obj/item/ammo_casing/c9mm/fire
 
 /obj/item/ammo_box/magazine/smgm45
-	name = "SMG magazine (.45)"
+	name = "SMG magazine (.45 FMJ)"
 	icon_state = "c20r45-24"
 	base_icon_state = "c20r45"
-	ammo_type = /obj/item/ammo_casing/c45
+	ammo_type = /obj/item/ammo_casing/c45/fmj
 	caliber = CALIBER_45
 	max_ammo = 24
 
@@ -87,8 +87,40 @@
 	icon_state = "[base_icon_state]-[round(ammo_count(), 2)]"
 
 /obj/item/ammo_box/magazine/smgm45/ap
-	name = "SMG magazine (Armour Piercing .45)"
+	name = "SMG magazine (.45 AP)"
+	icon_state = "c20r45-24"
+	base_icon_state = "c20r45"
 	ammo_type = /obj/item/ammo_casing/c45/ap
+	caliber = CALIBER_45
+	max_ammo = 24
+
+/obj/item/ammo_box/magazine/smgm45/ap/update_icon_state()
+	. = ..()
+	icon_state = "[base_icon_state]-[round(ammo_count(), 2)]"
+
+/obj/item/ammo_box/magazine/smgm45/hp
+	name = "SMG magazine (.45 HP)"
+	icon_state = "c20r45-24"
+	base_icon_state = "c20r45"
+	ammo_type = /obj/item/ammo_casing/c45/hp
+	caliber = CALIBER_45
+	max_ammo = 24
+
+/obj/item/ammo_box/magazine/smgm45/hp/update_icon_state()
+	. = ..()
+	icon_state = "[base_icon_state]-[round(ammo_count(), 2)]"
+
+/obj/item/ammo_box/magazine/smgm45/i
+	name = "SMG magazine (.45 Incendiary)"
+	icon_state = "c20r45-24"
+	base_icon_state = "c20r45"
+	ammo_type = /obj/item/ammo_casing/c45/i
+	caliber = CALIBER_45
+	max_ammo = 24
+
+/obj/item/ammo_box/magazine/smgm45/i/update_icon_state()
+	. = ..()
+	icon_state = "[base_icon_state]-[round(ammo_count(), 2)]"
 
 /obj/item/ammo_box/magazine/smgm45/incen
 	name = "SMG magazine (Incendiary .45)"

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -2,9 +2,31 @@
 
 /obj/projectile/bullet/a556
 	name = "5.56mm bullet"
-	damage = 35
+	damage = 30
+
+/obj/projectile/bullet/a556/ap
+	name = "5.56mm armour-piercing bullet"
+	damage = 25
 	armour_penetration = 30
-	wound_bonus = -40
+	wound_bonus = -30
+
+/obj/projectile/bullet/a556/hp
+	name = "5.56mm hollowpoint bullet"
+	damage = 35
+	armour_penetration = -30
+	wound_bonus = 30
+
+/obj/projectile/bullet/a556/i
+	name = "5.56mm incendiary bullet"
+	damage = 25
+	armour_penetration = -50
+
+/obj/projectile/bullet/a556/i/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.adjust_fire_stacks(6)
+		M.IgniteMob()
 
 /obj/projectile/bullet/a556/phasic
 	name = "5.56mm phasic bullet"
@@ -18,9 +40,30 @@
 /obj/projectile/bullet/a762
 	name = "7.62 bullet"
 	damage = 60
-	armour_penetration = 10
-	wound_bonus = -45
-	wound_falloff_tile = 0
+
+/obj/projectile/bullet/a762/ap
+	name = "7.62 armour-piercing bullet"
+	damage = 50
+	armour_penetration = 50
+	wound_bonus = -30
+
+/obj/projectile/bullet/a762/hp
+	name = "7.62 hollowpoint bullet"
+	damage = 70
+	armour_penetration = -50
+	wound_bonus = 30
+
+/obj/projectile/bullet/a762/i
+	name = "7.62 incendiary bullet"
+	damage = 50
+	armour_penetration = -50
+
+/obj/projectile/bullet/a762/i/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.adjust_fire_stacks(6)
+		M.IgniteMob()
 
 /obj/projectile/bullet/a762/enchanted
 	name = "enchanted 7.62 bullet"

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -8,12 +8,27 @@
 
 /obj/projectile/bullet/c45/ap
 	name = ".45 armor-piercing bullet"
+	damage = 25
 	armour_penetration = 50
+	wound_bonus = -30
 
-/obj/projectile/bullet/incendiary/c45
+/obj/projectile/bullet/c45/hp
+	name = ".45 hollowpoint bullet"
+	damage = 40
+	armour_penetration = -50
+	wound_bonus = 30
+
+/obj/projectile/bullet/c45/i
 	name = ".45 incendiary bullet"
-	damage = 15
-	fire_stacks = 2
+	damage = 25
+	armour_penetration = -50
+
+/obj/projectile/bullet/c45/i/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/M = target
+		M.adjust_fire_stacks(6)
+		M.IgniteMob()
 
 /obj/projectile/bullet/c45/fmj
 	name = ".45 FMJ bullet"
@@ -21,6 +36,10 @@
 	wound_bonus = -10
 	wound_falloff_tile = -10
 
+/obj/projectile/bullet/incendiary/c45
+	name = ".45 incendiary bullet"
+	damage = 15
+	fire_stacks = 2
 
 // 4.6x30mm (Autorifles)
 

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -70,7 +70,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/m45
-	name = "Speed Loader (.45 Rubber)"
+	name = "Magazine (.45 Rubber - Handgun)"
 	desc = "Designed to quickly reload the Liberator handgun. Rubber bullets are bouncy and less-than-lethal."
 	id = "m45"
 	build_type = PROTOLATHE | AWAY_LATHE
@@ -80,7 +80,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/m45_fmj
-	name = "Speed Loader (.45 FMJ)"
+	name = "Magazine (.45 FMJ - Handgun)"
 	desc = "Designed to quickly reload the Liberator handgun.."
 	id = "m45_fmj"
 	build_type = PROTOLATHE | AWAY_LATHE
@@ -90,7 +90,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/m9mm
-	name = "Speed Loader (9mm Rubber)"
+	name = "Magazine (9mm Rubber)"
 	desc = "Designed to quickly reload the Equalizer handgun. Rubber bullets are bouncy and less-than-lethal."
 	id = "m9mm"
 	build_type = PROTOLATHE | AWAY_LATHE
@@ -100,12 +100,132 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/m9mm_fmj
-	name = "Speed Loader (9mm FMJ)"
+	name = "Magazine (9mm FMJ)"
 	desc = "Designed to quickly reload the Equalizer handgun."
 	id = "m9mm_fmj"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/magazine/m9mm/fmj
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/m556
+	name = "Magazine (5.56 FMJ)"
+	desc = "Designed to quickly reload the Valiant assault rifle."
+	id = "m556"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 30000)
+	build_path = /obj/item/ammo_box/magazine/m556
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/m556ap
+	name = "Magazine (5.56 AP)"
+	desc = "Designed to quickly reload the Valiant assault rifle. Armour-piercing rounds cut through armour, but cause less trauma on impact."
+	id = "m556ap"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 40000, /datum/material/uranium = 5000)
+	build_path = /obj/item/ammo_box/magazine/m556/ap
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/m556hp
+	name = "Magazine (5.56 HP)"
+	desc = "Designed to quickly reload the Valiant assault rifle. Hollowpoints expand on impact, but are stopped easily by armour."
+	id = "m556hp"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 40000, /datum/material/gold = 5000)
+	build_path = /obj/item/ammo_box/magazine/m556/hp
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/m556i
+	name = "Magazine (5.56 Incendiary)"
+	desc = "Designed to quickly reload the Valiant assault rifle. Incendiaries cause minimal damage, but cause fires on impact."
+	id = "m556i"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 40000, /datum/material/plasma = 5000)
+	build_path = /obj/item/ammo_box/magazine/m556/i
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/a762
+	name = "Stripper Clip (7.62 FMJ)"
+	desc = "Designed to quickly reload the Memoria bolt-action rifle."
+	id = "a762"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 30000)
+	build_path = /obj/item/ammo_box/a762
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/a762ap
+	name = "Stripper Clip (7.62 AP)"
+	desc = "Designed to quickly reload the Memoria bolt-action rifle. Armour-piercing rounds cut through armour, but cause less trauma on impact."
+	id = "a762ap"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 40000, /datum/material/uranium = 5000)
+	build_path = /obj/item/ammo_box/a762/ap
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/a762hp
+	name = "Stripper Clip (7.62 HP)"
+	desc = "Designed to quickly reload the Memoria bolt-action rifle. Hollowpoints expand on impact, but are stopped easily by armour."
+	id = "a762hp"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 40000, /datum/material/gold = 5000)
+	build_path = /obj/item/ammo_box/a762/hp
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/a762i
+	name = "Stripper Clip (7.62 Incendiary)"
+	desc = "Designed to quickly reload the Memoria bolt-action rifle. Incendiaries cause minimal damage, but cause fires on impact."
+	id = "a762i"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 40000, /datum/material/plasma = 5000)
+	build_path = /obj/item/ammo_box/a762/i
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/smgm45
+	name = "Magazine (.45 FMJ - SMG)"
+	desc = "Designed to quickly reload the Helios PDW."
+	id = "smgm45"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 30000)
+	build_path = /obj/item/ammo_box/magazine/smgm45
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/smgm45ap
+	name = "Magazine (.45 AP - SMG)"
+	desc = "Designed to quickly reload the Helios PDW. Armour-piercing rounds cut through armour, but cause less trauma on impact."
+	id = "smgm45ap"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 40000, /datum/material/uranium = 5000)
+	build_path = /obj/item/ammo_box/magazine/smgm45/ap
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/smgm45hp
+	name = "Magazine (.45 HP - SMG)"
+	desc = "Designed to quickly reload the Helios PDW. Hollowpoints expand on impact, but are stopped easily by armour."
+	id = "smgm45hp"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 40000, /datum/material/gold = 5000)
+	build_path = /obj/item/ammo_box/magazine/smgm45/hp
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/smgm45i
+	name = "Magazine (.45 Incendiary - SMG)"
+	desc = "Designed to quickly reload the Helios PDW. Incendiaries cause minimal damage, but cause fires on impact."
+	id = "smgm45i"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 40000, /datum/material/plasma = 5000)
+	build_path = /obj/item/ammo_box/magazine/smgm45/i
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -69,7 +69,10 @@
 		"m45",
 		"m45_fmj",
 		"m9mm",
-		"m9mm_fmj"
+		"m9mm_fmj",
+		"smgm45",
+		"a762",
+		"m556"
 	)
 
 /datum/techweb_node/mmi
@@ -1370,6 +1373,15 @@
 	design_ids = list(
 		"pin_testing",
 		"tele_shield",
+		"m556ap",
+		"m556hp",
+		"m556i",
+		"a762ap",
+		"a762hp",
+		"a762i",
+		"smgm45ap",
+		"smgm45hp",
+		"smgm45i"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -18,8 +18,10 @@
 		/obj/item/restraints/legcuffs/bola/energy = 7,
 		/obj/item/gun/ballistic/revolver/revolution = 3,
 		/obj/item/gun/ballistic/automatic/pistol/liberator = 3,
-		/obj/item/gun/ballistic/automatic/pistol/equalizer = 3
-
+		/obj/item/gun/ballistic/automatic/pistol/equalizer = 3,
+		/obj/item/gun/ballistic/rifle/boltaction/brand_new = 3,
+		/obj/item/gun/ballistic/automatic/ar/modular = 3,
+		/obj/item/gun/ballistic/automatic/c20r/unrestricted/cmg1 = 3
 	)
 	contraband = list(
 		/obj/item/clothing/glasses/sunglasses = 2,

--- a/starbloom_modules/aesthetics/guns/code/guns.dm
+++ b/starbloom_modules/aesthetics/guns/code/guns.dm
@@ -239,11 +239,12 @@
 	zoom_out_amt = 5
 	slot_flags = ITEM_SLOT_BACK
 	mag_display = TRUE
-
+// Sec Assault Rifle
 /obj/item/gun/ballistic/automatic/ar/modular
-	name = "NT ARG-63"
-	desc = "Nanotrasen's prime ballistic option based on the Stoner design, fitted with a light polymer frame and other tactical furniture - nicknamed 'Boarder' by Special Operations teams."
+	name = "5.56 Valiant"
+	desc = "A modern, advanced Security-issue rifle fitted with a light polymer frame and other tactical furniture."
 	icon = 'starbloom_modules/aesthetics/guns/icons/guns_gubman2.dmi'
+	fire_sound = 'sound/weapons/gun/pistol/starbloom_9mm.ogg'
 	icon_state = "arg"
 	inhand_icon_state = "arg"
 	can_suppress = FALSE
@@ -272,9 +273,11 @@
 	sawn_desc = "An extremely sawn-off Mosin Nagant, popularly known as an \"obrez\". There was probably a reason it wasn't manufactured this short to begin with."
 	icon = 'starbloom_modules/aesthetics/guns/icons/guns.dmi'
 
+// Sec Bolt Action
 /obj/item/gun/ballistic/rifle/boltaction/brand_new
-	name = "\improper Mosin Nagant M39"
-	desc = "A freshly-produced Mosin Nagant variant issued by Nanotrasen for their interns. You would rather not damage it."
+	name = "7.62 Memoria"
+	desc = "A classic variant of an old Earth rifle. Dated, but powerful."
+	fire_sound = 'sound/weapons/gun/revolver/starbloom_revolver.ogg'
 	icon = 'starbloom_modules/aesthetics/guns/icons/guns.dmi'
 
 /obj/item/gun/ballistic/rifle/boltaction/brand_new/quartermaster
@@ -299,11 +302,12 @@
 	name = "\improper Type-69 surplus rifle"
 	desc = "One of countless obsolete ballistic rifles that still sees use as a cheap deterrent. Uses 10mm ammo and its bulky frame prevents one-hand firing."
 	icon = 'starbloom_modules/aesthetics/guns/icons/guns.dmi'
-
+// Sec PDW
 /obj/item/gun/ballistic/automatic/c20r/unrestricted/cmg1
-	name = "\improper NT CMG-1"
-	desc = "A bullpup three-round burst .45 PDW with an eerily familiar design. It has a foldable stock and a dot sight."
+	name = ".45 Helios"
+	desc = "A bullpup three-round burst .45 PDW. It has a foldable stock and a dot sight."
 	icon_state = "cmg1"
+	fire_sound = 'sound/weapons/gun/pistol/starbloom_45.ogg'
 	icon = 'starbloom_modules/aesthetics/guns/icons/guns.dmi'
 
 /obj/item/gun/ballistic/automatic/ar/modular/model75


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds three guns for Security to choose from as part of our move away from traditional energy weapons. There's an SMG, an assault rifle, and a bolt action rifle. Currently, because I am too dumb to make weapons into prefs or steal Skyrat's tokens system, three of each are available for purchase in the sec vendor. Ammo is printable at the sec lathe. Different ammo categories exist. AP cuts through armour. HP cuts through people. Incendiary sets shit on fire. Advanced ammo is locked behind weapons tech.

![image](https://user-images.githubusercontent.com/58074918/167710759-448450ee-b300-4df0-94b8-dbf4c7be3126.png)

## Why It's Good For The Game

Matches our design direction, but probably will need some balancing ngl

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
expansion: Expands gunsec with 3 new guns and 3 new ammo types for each.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
