### PR TITLE
Removes golems from atmos

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -467,7 +467,6 @@ GLOBAL_LIST_INIT(abductor_recipes, list ( \
 
 //Metal Hydrogen
 GLOBAL_LIST_INIT(metalhydrogen_recipes, list(
-	new /datum/stack_recipe("incomplete servant golem shell", /obj/item/golem_shell/servant, req_amount=20, res_amount=1),
 	new /datum/stack_recipe("ancient armor", /obj/item/clothing/suit/armor/elder_atmosian, req_amount = 5, res_amount = 1),
 	new /datum/stack_recipe("ancient helmet", /obj/item/clothing/head/helmet/elder_atmosian, req_amount = 3, res_amount = 1),
 	new /datum/stack_recipe("metallic hydrogen axe", /obj/item/fireaxe/metal_h2_axe, req_amount = 15, res_amount = 1),


### PR DESCRIPTION
## About The Pull Request

Extension of https://github.com/StarbloomSS13/StarbloomSS13/pull/27

## Why It's Good For The Game

see https://github.com/StarbloomSS13/StarbloomSS13/pull/27

## Changelog
:cl:
del: Golem shells have been removed from the metal hydrogen recipe list.
/:cl: