### PR TITLE
Tentative fix for a headshot runtime

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/headshot.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/headshot.dm
@@ -15,6 +15,8 @@
 	target?.dna.features["headshot"] = value
 
 /datum/preference/text/headshot/is_valid(value)
+	if(value == "")
+		return TRUE
 	if(!length(value)) //Just to get blank ones out of the way
 		return FALSE
 	if(!findtext(value, "https://", 1, 9))


### PR DESCRIPTION
Should fix this
```
[00:51:23] Runtime in _preference.dm,255: Couldn't write the default value for /datum/preference/text/headshot (received )
  proc name: read preference (/datum/preferences/proc/read_preference)
  src: /datum/preferences (/datum/preferences)
  call stack:
  /datum/preferences (/datum/preferences): read preference(/datum/preference/text/headsho... (/datum/preference/text/headshot))
  /datum/preferences (/datum/preferences): apply prefs to(River Sheets (/mob/living/carbon/human), 1)
  River Sheets (/mob/living/carbon/human): apply prefs job(/datum/client_interface (/datum/client_interface), /datum/job/assistant (/datum/job/assistant))
  /datum/unit_test/anonymous_the... (/datum/unit_test/anonymous_themes): Run()
  RunUnitTest(/datum/unit_test/anonymous_the... (/datum/unit_test/anonymous_themes), /list (/list))
  RunUnitTests()
  /datum/callback (/datum/callback): InvokeAsync()
FAIL: /datum/unit_test/anonymous_themes 0.2s
    REASON #1: [00:51:23] Runtime in _preference.dm,255: Couldn't write the default value for /datum/preference/text/headshot (received )
  proc name: read preference (/datum/preferences/proc/read_preference)
  src: /datum/preferences (/datum/preferences)
  call stack:
  /datum/preferences (/datum/preferences): read preference(/datum/preference/text/headsho... (/datum/preference/text/headshot))
  /datum/preferences (/datum/preferences): apply prefs to(River Sheets (/mob/living/carbon/human), 1)
  River Sheets (/mob/living/carbon/human): apply prefs job(/datum/client_interface (/datum/client_interface), /datum/job/assistant (/datum/job/assistant))
  /datum/unit_test/anonymous_the... (/datum/unit_test/anonymous_themes): Run()
  RunUnitTest(/datum/unit_test/anonymous_the... (/datum/unit_test/anonymous_themes), /list (/list))
  RunUnitTests()
  /datum/callback (/datum/callback): InvokeAsync()
```