### PR TITLE
Adds in Synthetics.

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -84,6 +84,7 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 #define isdullahan(A) (is_species(A, /datum/species/dullahan))
 #define ismonkey(A) (is_species(A, /datum/species/monkey))
 #define isandroid(A) (is_species(A, /datum/species/android))
+#define issynthetic(A) (is_species(A, /datum/species/synthetic))
 
 //More carbon mobs
 #define isalien(A) (istype(A, /mob/living/carbon/alien))

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -103,6 +103,7 @@
 #define SPECIES_SHADOW "shadow"
 #define SPECIES_SKELETON "skeleton"
 #define SPECIES_SNAIL "snail"
+#define SPECIES_SYNTHETIC "synthetic"
 #define SPECIES_VAMPIRE "vampire"
 #define SPECIES_ZOMBIE "zombie"
 #define SPECIES_ZOMBIE_INFECTIOUS "memezombie"

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -387,6 +387,12 @@ Key procs
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 							/datum/language/monkey = list(LANGUAGE_ATOM))
 
+/datum/language_holder/synth //Not to be confused with synthetic, which is used in other purposes!
+	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+								/datum/language/machine = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
+							/datum/language/machine = list(LANGUAGE_ATOM))
+
 /datum/language_holder/empty
 	understood_languages = list()
 	spoken_languages = list()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -506,9 +506,6 @@
 		owner.visible_message(span_danger("[owner] grabs [owner.p_their()] throat, struggling for breath!"), span_userdanger("You suddenly feel like you can't breathe!"))
 		failed = TRUE
 
-/obj/item/organ/lungs/get_availability(datum/species/owner_species)
-	return !(TRAIT_NOBREATH in owner_species.inherent_traits)
-
 /obj/item/organ/lungs/plasmaman
 	name = "plasma filter"
 	desc = "A spongy rib-shaped mass for filtering plasma from the air."

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -321,6 +321,7 @@ ROUNDSTART_RACES plasmaman
 
 ## Races that are better than humans in some ways, but worse in others
 ROUNDSTART_RACES ethereal
+ROUNDSTART_RACES synthetic
 #ROUNDSTART_RACES jelly
 #ROUNDSTART_RACES abductor
 #ROUNDSTART_RACES synth

--- a/starbloom_modules/synthetics/code/preferences/synth_prefs.dm
+++ b/starbloom_modules/synthetics/code/preferences/synth_prefs.dm
@@ -1,0 +1,67 @@
+//Do we hide our identity to that of a human?
+/datum/preference/toggle/hide_synth_identity
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "hide_synth_identity"
+	priority = PREFERENCE_PRIORITY_NAME_MODIFICATIONS
+	default_value = FALSE
+
+/datum/preference/toggle/hide_synth_identity/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	if(!issynthetic(target))
+		return
+
+	if(value)
+		target.dna.species.name = "Human"
+	else
+		var/datum/species/synthetic/our_species = target.dna.species
+		our_species.name = our_species.initial_species_name
+
+/datum/preference/toggle/hide_synth_identity/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return ispath(preferences.read_preference(/datum/preference/choiced/species), /datum/species/synthetic)
+
+//Can we metabolize chemicals?
+/datum/preference/toggle/synth_can_metabolize
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "synth_can_metabolize"
+	priority = PREFERENCE_PRIORITY_NAME_MODIFICATIONS
+	default_value = FALSE
+
+/datum/preference/toggle/synth_can_metabolize/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	if(!issynthetic(target))
+		return
+
+	if(value)
+		target.dna.species.inherent_traits -= TRAIT_NOMETABOLISM
+		target.status_traits -= TRAIT_NOMETABOLISM
+
+/datum/preference/toggle/synth_can_metabolize/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return ispath(preferences.read_preference(/datum/preference/choiced/species), /datum/species/synthetic)
+
+//Can we become hungry?
+/datum/preference/toggle/synth_hunger
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "synth_hunger"
+	priority = PREFERENCE_PRIORITY_NAME_MODIFICATIONS
+	default_value = FALSE
+
+/datum/preference/toggle/synth_hunger/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	if(!issynthetic(target))
+		return
+
+	if(value)
+		target.dna.species.inherent_traits -= TRAIT_NOHUNGER
+		target.status_traits -= TRAIT_NOHUNGER
+
+/datum/preference/toggle/synth_hunger/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return preferences.read_preference(/datum/preference/toggle/synth_can_metabolize)

--- a/starbloom_modules/synthetics/code/species/synthetic.dm
+++ b/starbloom_modules/synthetics/code/species/synthetic.dm
@@ -1,0 +1,45 @@
+///Generic synthetic humanoids. Usable as either synths, or as a basetype in code for other robotic species
+/datum/species/synthetic
+	name = "Synthetic Humanoid"
+	id = SPECIES_SYNTHETIC
+	species_traits = list(NO_DNA_COPY, NOTRANSSTING, EYECOLOR, HAIR, FACEHAIR, LIPS, HAS_FLESH, HAS_BONE)
+	inherent_traits = list(
+		TRAIT_ADVANCEDTOOLUSER,
+		TRAIT_NOMETABOLISM,
+		TRAIT_NOHUNGER,
+		TRAIT_CAN_STRIP,
+		TRAIT_TOXIMMUNE,
+		TRAIT_NOBREATH,
+		TRAIT_RADIMMUNE,
+		TRAIT_GENELESS,
+		TRAIT_NOCLONELOSS,
+		TRAIT_CAN_USE_FLIGHT_POTION,
+	) //Synths metabolization and hunger is handled by prefs
+	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
+	use_skintones = 1
+	meat = null
+	damage_overlay_type = "synth"
+	payday_modifier = 0.6 //People are afraid of synths, and the revenue service KNOWS ALL
+	mutant_bodyparts = list("wings" = "None")
+	mutantappendix = null //Sorry, no appendix for synths
+	species_language_holder = /datum/language_holder/synth
+	wings_icons = list("Robotic")
+	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
+	examine_limb_id = SPECIES_HUMAN
+	///The initial name of the species, before prefs change it.
+	var/initial_species_name = "Synthetic Humanoid"
+
+/datum/species/synthetic/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+	. = ..()
+	//If we don't eat, set our hunger
+	for(var/key in inherent_traits)
+		if(key == TRAIT_NOHUNGER)
+			C.set_safe_hunger_level()
+
+/datum/species/synthetic/get_species_description()
+	return "A synthetic humanoid, possibly hiding it's status from the organics around it." //Placeholder description until lore rewrites on species
+
+/datum/species/synthetic/get_species_lore()
+	return list(
+		"Synths are created from pretty much anywhere for any reason. It's up to you to decide their lore.",
+	) //Placeholder until lore rewrites on species

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4519,4 +4519,6 @@
 #include "starbloom_modules\hyposprays\code\hypovials.dm"
 #include "starbloom_modules\mortis\mortis.dm"
 #include "starbloom_modules\pixel_shift\code\pixel_shift.dm"
+#include "starbloom_modules\synthetics\code\preferences\synth_prefs.dm"
+#include "starbloom_modules\synthetics\code\species\synthetic.dm"
 // END_INCLUDE

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
@@ -190,3 +190,21 @@ export const headshot: Feature<string> = {
   description: "Add an image to your character, visible on close examination. Requires it be formatted properly.",
   component: FeatureShortTextInput,
 };
+
+export const hide_synth_identity: FeatureToggle = {
+  name: "Hide Synthetic Identity",
+  description: "Do you want your identity to show up as human on things like medical scanners?",
+  component: CheckboxInput,
+};
+
+export const synth_can_metabolize: FeatureToggle = {
+  name: "Chemical Metabolizing",
+  description: "Do you want to be able to metabolize and process chemicals?",
+  component: CheckboxInput,
+};
+
+export const synth_hunger: FeatureToggle = {
+  name: "Hunger",
+  description: "Do you want to become hungry? Just like one of those regular organics?",
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

This PR adds in synthetics, which are a robotic species and intended to be the base type for other robotic species.

They have toggles for hiding their species (showing up as human instead), having metabolism, and if they have hunger.
Do note that their default organs are organic, as you can choose if you want organic or cybernetic organs in preferences.

This PR also removes an old bit of code where humans with the nobreath trait spawn without lungs, presumably before ways of changing lungs directly were in the game.

## Why It's Good For The Game

robots are cool :)
Also we kind of want things like IPCs down the line.