### PR TITLE
Gives everyone more save slots.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//doohickeys for savefiles
 	var/path
 	var/default_slot = 1 //Holder so it doesn't default to slot 1, rather the last one used
-	var/max_save_slots = 3
+	var/max_save_slots = 12
 
 	//non-preference stuff
 	var/muted = 0
@@ -99,7 +99,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			load_path(C.ckey)
 			unlock_content = !!C.IsByondMember()
 			if(unlock_content)
-				max_save_slots = 8
+				max_save_slots = 14
 
 	// give them default keybinds and update their movement keys
 	key_bindings = deep_copy_list(GLOB.default_hotkeys)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives everyone more save slots. Everyone gets 12, Byond Donors have been nerfed. Rather than a 166% buff to save slots they now only get a 16% buff to a total of 14 slots because any more would be cluttered.

## Why It's Good For The Game

I don't have enough save slots, nobody has enough save slots, those who ought to know have told me how it's got to be and the correct answer is 12.

## Changelog

:cl:

+Players have been buffed. 3 -> 12 save slots. A remarkable 300% increase!

-Byond Donors have been nerfed. Rather than a 166% increase to save slots they now only get a 16% buff to a total of 14 slots because any more would be cluttered.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
