### PR TITLE
Shelve some events and disable dynamic rulesets

### DIFF
--- a/code/modules/antagonists/revenant/revenant_spawn_event.dm
+++ b/code/modules/antagonists/revenant/revenant_spawn_event.dm
@@ -3,7 +3,7 @@
 /datum/round_event_control/revenant
 	name = "Spawn Revenant" // Did you mean 'griefghost'?
 	typepath = /datum/round_event/ghost_role/revenant
-	weight = 7
+	weight = 0
 	max_occurrences = 1
 	min_players = 5
 	dynamic_should_hijack = TRUE

--- a/code/modules/antagonists/slaughter/slaughterevent.dm
+++ b/code/modules/antagonists/slaughter/slaughterevent.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/slaughter
 	name = "Spawn Slaughter Demon"
 	typepath = /datum/round_event/ghost_role/slaughter
-	weight = 1 //Very rare
+	weight = 0 //Very rare
 	max_occurrences = 1
 	earliest_start = 1 HOURS
 	min_players = 20

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -2,7 +2,7 @@
 	name = "Aurora Caelus"
 	typepath = /datum/round_event/aurora_caelus
 	max_occurrences = 1
-	weight = 1
+	weight = 0
 	earliest_start = 5 MINUTES
 
 /datum/round_event_control/aurora_caelus/canSpawnEvent(players)

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/blob
 	name = "Blob"
 	typepath = /datum/round_event/ghost_role/blob
-	weight = 10
+	weight = 0
 	max_occurrences = 1
 
 	min_players = 20

--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/brain_trauma
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
-	weight = 25
+	weight = 0
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/brand_intelligence
 	name = "Brand Intelligence"
 	typepath = /datum/round_event/brand_intelligence
-	weight = 5
+	weight = 0 // fok of
 
 	min_players = 15
 	max_occurrences = 1

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -2,7 +2,7 @@
 	name = "Bureaucratic Error"
 	typepath = /datum/round_event/bureaucratic_error
 	max_occurrences = 1
-	weight = 5
+	weight = 0
 
 /datum/round_event/bureaucratic_error
 	announceWhen = 1

--- a/code/modules/events/fugitive_spawning.dm
+++ b/code/modules/events/fugitive_spawning.dm
@@ -2,6 +2,7 @@
 	name = "Spawn Fugitives"
 	typepath = /datum/round_event/ghost_role/fugitives
 	max_occurrences = 1
+	weight = 0
 	min_players = 20
 	earliest_start = 30 MINUTES //deadchat sink, lets not even consider it early on.
 

--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/grid_check
 	name = "Grid Check"
 	typepath = /datum/round_event/grid_check
-	weight = 10
+	weight = 0
 	max_occurrences = 3
 
 /datum/round_event/grid_check

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -14,6 +14,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	max_occurrences = 5
 	var/atom/special_target
 	var/force_looping = FALSE
+	weight = 0
 
 /datum/round_event_control/immovable_rod/admin_setup()
 	if(!check_rights(R_FUN))

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/mass_hallucination
 	name = "Mass Hallucination"
 	typepath = /datum/round_event/mass_hallucination
-	weight = 10
+	weight = 0
 	max_occurrences = 2
 	min_players = 1
 

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -3,7 +3,7 @@
 /datum/round_event_control/meteor_wave
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
-	weight = 4
+	weight = 0
 	min_players = 15
 	max_occurrences = 3
 	earliest_start = 25 MINUTES
@@ -56,7 +56,7 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 5
+	weight = 0
 	min_players = 20
 	max_occurrences = 3
 	earliest_start = 35 MINUTES
@@ -67,7 +67,7 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 7
+	weight = 0
 	min_players = 25
 	max_occurrences = 3
 	earliest_start = 45 MINUTES

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -2,7 +2,7 @@
 	name = "Lone Operative"
 	typepath = /datum/round_event/ghost_role/operative
 	weight = 0 //its weight is relative to how much stationary and neglected the nuke disk is. See nuclearbomb.dm. Shouldn't be dynamic hijackable.
-	max_occurrences = 1
+	max_occurrences = 0
 
 /datum/round_event/ghost_role/operative
 	minimum_required = 1

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/portal_storm_syndicate
 	name = "Portal Storm: Syndicate Shocktroops"
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
-	weight = 2
+	weight = 0
 	min_players = 15
 	earliest_start = 30 MINUTES
 

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -2,6 +2,7 @@
 	name = "Grey Tide"
 	typepath = /datum/round_event/grey_tide
 	max_occurrences = 2
+	weight = 0
 	min_players = 5
 
 /datum/round_event/grey_tide

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -19,8 +19,7 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 /datum/round_event_control/sentience
 	name = "Random Human-level Intelligence"
 	typepath = /datum/round_event/ghost_role/sentience
-	weight = 10
-
+	weight = 0
 
 /datum/round_event/ghost_role/sentience
 	minimum_required = 1

--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -2,7 +2,7 @@
 	name = "Wisdom cow"
 	typepath = /datum/round_event/wisdomcow
 	max_occurrences = 1
-	weight = 20
+	weight = 0
 
 /datum/round_event/wisdomcow/announce(fake)
 	priority_announce("A wise cow has been spotted in the area. Be sure to ask for her advice.", "Nanotrasen Cow Ranching Agency")

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -35,6 +35,10 @@
 			]
 		},
 
+		"Malfunctioning AI": {
+			"weight": 0
+		},
+
 		"Blood Brothers": {
 			"weight": 0
 		},
@@ -64,6 +68,18 @@
 		},
 
 		"Families": {
+			"weight": 0
+		},
+
+		"Clown Operatives": {
+			"weight": 0
+		},
+
+		"Meteors": {
+			"weight": 0
+		},
+
+		"Thieves": {
 			"weight": 0
 		}
 	},

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -135,6 +135,22 @@
 
 		"Spiders": {
 			"weight": 0
+		},
+
+		"Revenant": {
+			"weight": 0
+		},
+
+		"Sentient Disease": {
+			"weight": 0
+		},
+
+		"Space Pirates": {
+			"weight": 0
+		},
+
+		"Obsessed": {
+			"weight": 0
 		}
 	},
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Takes the following events out of rotation:
Revenant, Slaughter Demon, Aurora Caelus, Blob, Spontaneous Brain Trauma, Brand Intelligence, Bureaucratic Error, Fugitives, Grid Check, Immovable Rod, Mass Hallucinations, All Meteor Waves except Normal, Lone Operative, Portal Storm, Grey Tide, Random Human Level Intelligence and Wisdom Cow.

Furthermore, this PR disables all dynamic rulesets that have been left enabled by the config.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Some events really suck in the context of high roleplay, like Rampant Intelligence or Spontaneous Brain Trauma. Since antagonists are largely determined by OPFOR submissions, we should also not let dynamic execute rulesets. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
remove: Some events have been taken out of the rotation.
remove: All dynamic rulesets have been disabled, as OPFOR is a replacement for them. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
