### PR TITLE
Re-adds Silver to the dispenser and plumbing.

### DIFF
--- a/code/modules/plumbing/plumbers/synthesizer.dm
+++ b/code/modules/plumbing/plumbers/synthesizer.dm
@@ -32,6 +32,7 @@
 		/datum/reagent/potassium,
 		/datum/reagent/uranium/radium,
 		/datum/reagent/silicon,
+		/datum/reagent/silver,
 		/datum/reagent/sodium,
 		/datum/reagent/stable_plasma,
 		/datum/reagent/consumable/sugar,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -58,6 +58,7 @@
 		/datum/reagent/potassium,
 		/datum/reagent/uranium/radium,
 		/datum/reagent/silicon,
+		/datum/reagent/silver,
 		/datum/reagent/sodium,
 		/datum/reagent/stable_plasma,
 		/datum/reagent/consumable/sugar,

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -756,18 +756,6 @@
 	required_reagents = list(/datum/reagent/plasma_oxide = 1,/datum/reagent/stabilizing_agent = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
 
-/datum/chemical_reaction/silver_solidification
-	required_reagents = list(/datum/reagent/silver = 20, /datum/reagent/carbon = 10)
-	required_temp = 630
-	mob_react = FALSE
-	reaction_flags = REACTION_INSTANT
-	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
-
-/datum/chemical_reaction/silver_solidification/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	var/location = get_turf(holder.my_atom)
-	for(var/i in 1 to created_volume)
-		new /obj/item/stack/sheet/mineral/silver(location)
-
 /datum/chemical_reaction/bone_gel
 	required_reagents = list(/datum/reagent/bone_dust = 10, /datum/reagent/carbon = 10)
 	required_temp = 630


### PR DESCRIPTION
## About The Pull Request

Frankly I don't actually think this'll be merged and I mostly did it as an exercise to see how easily I could fuck with the contents of the chem dispenser. Was mostly just an exercise on my end to see how easily I can fuck with a few things. This also tries not to touch the availability of solid silver by re-removing the solidifcation recipe, so it shouldn't fuck with the balance too hard besides making Aiuri mostly obsolete except for mixing with Lenturi and the specific interactions it has with organ damage.

## Why It's Good For The Game

I'm going to be honest here and just say "I played a round where we didn't get silver for 30 minutes and I wanted to make drugs and couldn't and I didn't think this was a new innovative addition to the game"
Also adding silver to the plumbing machines means you can easily automate the production of hard drugs (Blastoff)

## Changelog

:cl:
add: added silver back to the chemistry machines, the oppression of anthro wolfpeople rages on.
del: removed silver solidifcation recipe so cargo can't just mass produce silver
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
