### PR TITLE
Removes the male sigh sound effect.

### DIFF
--- a/starbloom_modules/emotes/code/emotes.dm
+++ b/starbloom_modules/emotes/code/emotes.dm
@@ -99,9 +99,8 @@
 
 /datum/emote/living/sigh/get_sound(mob/living/user)
 	if(iscarbon(user))
-		if(user.gender == MALE)
-			return 'starbloom_modules/emotes/sound/emotes/male/male_sigh.ogg'
-		return 'starbloom_modules/emotes/sound/emotes/female/female_sigh.ogg'
+		if(user.gender == FEMALE)
+			return 'starbloom_modules/emotes/sound/emotes/female/female_sigh.ogg' //Only female has a sound because the male one didn't fit.
 	return
 
 /datum/emote/living/sniff


### PR DESCRIPTION
## About The Pull Request

This PR removes the sound effect when a male character sighs.

## Why It's Good For The Game

It uh, it doesn't sound like sighing. It sounds like _something else which cannot be said here._

## Changelog
:cl:
sounddel: Sighing as a male no longer has you produce a sound.
/:cl: