### PR TITLE
Adds the ability to toggle skintones.

### DIFF
--- a/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
+++ b/modular_skyrat/master_files/code/modules/client/preferences/mutant_parts.dm
@@ -490,3 +490,22 @@
 	savefile_key = "frills_emissive"
 	relevant_mutant_bodypart = "frills"
 	type_to_check = /datum/preference/toggle/frills
+
+/datum/preference/toggle/skintone_toggle
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	priority = PREFERENCE_PRIORITY_GENDER //Priority is set to be higher than the species pref.
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "skintone_toggle"
+
+/datum/preference/toggle/skintone_toggle/apply_to_human(mob/living/carbon/human/target, value)
+	if(value)
+		target.dna.species.species_traits -= MUTCOLORS
+		target.dna.species.use_skintones = TRUE
+		target.update_body_parts()
+	else
+		target.dna.species.species_traits |= MUTCOLORS
+		target.dna.species.use_skintones = FALSE
+		target.update_body_parts()
+
+/datum/preference/toggle/skintone_toggle/create_informed_default_value(datum/preferences/preferences)
+	return ispath(preferences.read_preference(/datum/preference/choiced/species), /datum/species/human)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/species_features.tsx
@@ -298,3 +298,9 @@ export const frills_emissive: Feature<boolean[]> = {
   description: "Want to have a fancy species name? Put it here, or leave it blank.",
   component: FeatureTriBoolInput,
 };
+
+export const skintone_toggle: FeatureToggle = {
+  name: "Skintones Toggle",
+  description: "Change between using skintones or mutant colors.",
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

This PR adds in the ability to toggle skintones in preferences, allowing humans to use mutant colors and other species to use skin colors.

## Why It's Good For The Game

More customization's always neat. Also, golden humans.
