### PR TITLE
Returns Buckshot (not slugs) to the lathe.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -872,6 +872,14 @@
 	build_path = /obj/item/ammo_casing/shotgun/incendiary
 	category = list("hacked", "Security")
 
+/datum/design/buckshot
+	name = "Buckshot Shell"
+	id = "buckshot"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list("hacked", "Security")
+
 /datum/design/riot_dart
 	name = "Foam Riot Dart"
 	id = "riot_dart"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -229,6 +229,15 @@
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/buckshot/sec
+	id = "sec_bshot"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 4000)
+	build_path = /obj/item/ammo_casing/shotgun/buckshot //I'll be fully honest I probably did this wrong. It looks nothing like the rubbershot one. If this bothers you please fucking fix it aaaa
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	autolathe_exportable = FALSE
+
 /datum/design/rubbershot/sec
 	id = "sec_rshot"
 	build_type = PROTOLATHE | AWAY_LATHE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -56,6 +56,7 @@
 		"sec_beanbag_slug",
 		"sec_dart",
 		"sec_rshot",
+		"sec_bshot",
 		"space_heater",
 		"tech_disk",
 		"titaniumglass",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Readds buckshot to the autolathe (when hacked) and the security protolathe (at all times). Does not readd slugs to avoid stepping on the toes of existing ballistic weapons in our armory.

## Why It's Good For The Game

With our chunkier ballistic weapons, I genuinely do not think it's too much of a reach to readd buckshot alone. Slugs maybe, but buckshot itself trades the consistency and range of a rifle for a powerful 2-3 shot kill. With our increased projectile speed, long range is a bit more viable and it means short range specialized guns may actually find a niche.

also

![image](https://user-images.githubusercontent.com/91390185/179380805-e0c766b6-1cde-4db7-8557-b1b51428737f.png)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Buckshot has returned to the fucking lathes. Not slugs though.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
