### PR TITLE
Fix cryopods making new players temporarily colorblind

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -407,8 +407,11 @@
 		spawn_instance = new spawn_type(get_turf(spawn_point), null, player_client.mob)
 	else
 		spawn_instance = new spawn_type(player_client.mob.loc)
-		spawn_point.JoinPlayerHere(spawn_instance, TRUE)
 	spawn_instance.apply_prefs_job(player_client, src)
+	// due to extreme spaghetti code, JoinPlayerHere may *not* happen before applying player prefs
+	// enjoy this snowflake patch as a result
+	if(!ispath(spawn_type, /mob/living/silicon/ai))
+		spawn_point.JoinPlayerHere(spawn_instance, TRUE)
 	if(!player_client)
 		qdel(spawn_instance)
 		return // Disconnected while checking for the appearance ban.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Spaghetti code from putting someone to sleep in a cryopod and applying prefs afterwards made people permanently colorblind due to the way blindness was handled after eyes were reinserted. This PR snowflakes its way into the charts by moving new mobs to cryopods only after prefs have been applied. Big issue in the way traits/blindness works. 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

idk im still not happy with the solution

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Cryopods don't make you colorblind now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
