### PR TITLE
Minor Last Edict Spellcheck

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -87,6 +87,6 @@
 	imp_type = /obj/item/implant/radio
 
 /obj/item/implanter/radio/syndicate
-	name = "implanter (internal last edic radio)"
+	name = "implanter (internal last edict radio)"
 	imp_type = /obj/item/implant/radio/edict
 


### PR DESCRIPTION
I'm a moron

:cl:
spellcheck: The "last edic" has been written off as a rumor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
