### PR TITLE
Chameleon Gun Port

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -476,6 +476,7 @@
 	new /obj/item/radio/headset/chameleon(src)
 	new /obj/item/stamp/chameleon(src)
 	new /obj/item/pda/chameleon(src)
+	new /obj/item/gun/energy/laser/chameleon(src)
 
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -202,6 +202,9 @@
 		update_item(chameleon_list[picked_name])
 
 /datum/action/item_action/chameleon/change/proc/update_look(mob/user, obj/item/picked_item)
+	if(istype(target, /obj/item/gun/energy/laser/chameleon))
+		var/obj/item/gun/energy/laser/chameleon/chameleon_gun = target
+		chameleon_gun.set_chameleon_disguise(picked_item)
 	if(isliving(user))
 		var/mob/living/C = user
 		if(C.stat != CONSCIOUS)
@@ -761,3 +764,171 @@
 /obj/item/clothing/neck/chameleon/broken/Initialize(mapload)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
+
+/obj/item/gun/energy/laser/chameleon
+	var/datum/action/item_action/chameleon/change/chameleon_action
+
+	ammo_type = list(/obj/item/ammo_casing/energy/chameleon)
+	pin = /obj/item/firing_pin
+	automatic_charge_overlays = FALSE
+	can_select = FALSE
+
+	/// The vars copied over to our projectile on fire.
+	var/list/chameleon_projectile_vars
+
+	/// The badmin mode. Makes your projectiles act like the real deal.
+	var/real_hits = FALSE
+
+/obj/item/gun/energy/laser/chameleon/Initialize()
+	. = ..()
+	chameleon_action = new(src)
+	chameleon_action.chameleon_type = /obj/item/gun
+	chameleon_action.chameleon_name = "Gun"
+	chameleon_action.chameleon_blacklist = typecacheof(/obj/item/gun/energy/minigun)
+	chameleon_action.initialize_disguises()
+
+	recharge_newshot()
+	set_chameleon_disguise(/obj/item/gun/energy/laser)
+
+/obj/item/gun/energy/laser/chameleon/Destroy()
+	. = ..()
+	chameleon_projectile_vars.Cut()
+
+/obj/item/gun/energy/laser/chameleon/emp_act(severity)
+	return
+
+/**
+ * Description: Resets the currently loaded chameleon variables, essentially resetting it to brand new.
+ * Arguments: []
+ */
+/obj/item/gun/energy/laser/chameleon/proc/reset_chameleon_vars()
+	chameleon_projectile_vars = list()
+
+	if(chambered)
+		chambered.firing_effect_type = initial(chambered.firing_effect_type)
+
+	fire_sound = initial(fire_sound)
+	burst_size = initial(burst_size)
+	fire_delay = initial(fire_delay)
+	inhand_x_dimension = initial(inhand_x_dimension)
+	inhand_y_dimension = initial(inhand_y_dimension)
+
+	QDEL_NULL(chambered.loaded_projectile)
+	chambered.newshot()
+
+/**
+ * Description: Sets what gun we should be mimicking.
+ * Arguments: [obj/item/gun/gun_to_set (the gun we're trying to mimic)]
+ */
+/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_gun(obj/item/gun/gun_to_set)
+	if(!istype(gun_to_set))
+		stack_trace("[gun_to_set] is not a valid gun.")
+		return FALSE
+
+	fire_sound = gun_to_set.fire_sound
+	burst_size = gun_to_set.burst_size
+	fire_delay = gun_to_set.fire_delay
+	inhand_x_dimension = gun_to_set.inhand_x_dimension
+	inhand_y_dimension = gun_to_set.inhand_y_dimension
+
+	if(istype(gun_to_set, /obj/item/gun/ballistic))
+		var/obj/item/gun/ballistic/ball_gun = gun_to_set
+		var/obj/item/ammo_box/ball_ammo = new ball_gun.mag_type(gun_to_set)
+		qdel(ball_gun)
+
+		if(!istype(ball_ammo) || !ball_ammo.ammo_type)
+			qdel(ball_ammo)
+			return FALSE
+
+		var/obj/item/ammo_casing/ball_cartridge = new ball_ammo.ammo_type(gun_to_set)
+		set_chameleon_ammo(ball_cartridge)
+
+	else if(istype(gun_to_set, /obj/item/gun/magic))
+		var/obj/item/gun/magic/magic_gun = gun_to_set
+		var/obj/item/ammo_casing/magic_cartridge = new magic_gun.ammo_type(gun_to_set)
+		set_chameleon_ammo(magic_cartridge)
+
+	else if(istype(gun_to_set, /obj/item/gun/energy))
+		var/obj/item/gun/energy/energy_gun = gun_to_set
+		if(islist(energy_gun.ammo_type) && energy_gun.ammo_type.len)
+			var/obj/item/ammo_casing/energy_cartridge = energy_gun.ammo_type[1]
+			set_chameleon_ammo(energy_cartridge)
+
+	else if(istype(gun_to_set, /obj/item/gun/syringe))
+		var/obj/item/ammo_casing/syringe_cartridge = new /obj/item/ammo_casing/syringegun(src)
+		set_chameleon_ammo(syringe_cartridge)
+
+	else
+		var/obj/item/ammo_casing/default_cartridge = new /obj/item/ammo_casing(src)
+		set_chameleon_ammo(default_cartridge)
+
+/**
+ * Description: Sets the ammo type our gun should have.
+ * Arguments: [obj/item/ammo_casing/cartridge (the ammo_casing we're trying to copy)]
+ */
+/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_ammo(obj/item/ammo_casing/cartridge)
+	if(!istype(cartridge))
+		stack_trace("[cartridge] is not a valid ammo casing.")
+		return FALSE
+
+	var/obj/projectile/projectile = cartridge.loaded_projectile
+	set_chameleon_projectile(projectile)
+
+/**
+ * Description: Sets the current projectile variables for our chameleon gun.
+ * Arguments: [obj/projectile/template_projectile (the projectile we're trying to copy)]
+ */
+/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_projectile(obj/projectile/template_projectile)
+	if(!istype(template_projectile))
+		stack_trace("[template_projectile] is not a valid projectile.")
+		return FALSE
+
+	chameleon_projectile_vars = list("name" = "practice laser", "icon" = 'icons/obj/guns/projectiles.dmi', "icon_state" = "laser")
+
+	var/default_state = isnull(template_projectile.icon_state) ? "laser" : template_projectile.icon_state
+
+	chameleon_projectile_vars["name"] = template_projectile.name
+	chameleon_projectile_vars["icon"] = template_projectile.icon
+	chameleon_projectile_vars["icon_state"] = default_state
+	chameleon_projectile_vars["speed"] = template_projectile.speed
+	chameleon_projectile_vars["color"] = template_projectile.color
+	chameleon_projectile_vars["hitsound"] = template_projectile.hitsound
+	chameleon_projectile_vars["impact_effect_type"] = template_projectile.impact_effect_type
+	chameleon_projectile_vars["range"] = template_projectile.range
+	chameleon_projectile_vars["suppressed"] = template_projectile.suppressed
+	chameleon_projectile_vars["hitsound_wall"] = template_projectile.hitsound_wall
+	chameleon_projectile_vars["pass_flags"] = template_projectile.pass_flags
+
+	if(istype(chambered, /obj/item/ammo_casing/energy/chameleon))
+		var/obj/item/ammo_casing/energy/chameleon/cartridge = chambered
+
+		cartridge.loaded_projectile.name = template_projectile.name
+		cartridge.loaded_projectile.icon = template_projectile.icon
+		cartridge.loaded_projectile.icon_state = default_state
+		cartridge.loaded_projectile.speed = template_projectile.speed
+		cartridge.loaded_projectile.color = template_projectile.color
+		cartridge.loaded_projectile.hitsound = template_projectile.hitsound
+		cartridge.loaded_projectile.impact_effect_type = template_projectile.impact_effect_type
+		cartridge.loaded_projectile.range = template_projectile.range
+		cartridge.loaded_projectile.suppressed = template_projectile.suppressed
+		cartridge.loaded_projectile.hitsound_wall =	template_projectile.hitsound_wall
+		cartridge.loaded_projectile.pass_flags = template_projectile.pass_flags
+
+		cartridge.projectile_vars = chameleon_projectile_vars.Copy()
+
+	if(real_hits)
+		qdel(chambered.loaded_projectile)
+		chambered.projectile_type = template_projectile.type
+
+	qdel(template_projectile)
+
+
+/**
+ * Description: Resets our chameleon variables, then resets the entire gun to mimic the given guntype.
+ * Arguments: [guntype (the gun we're copying, pathtyped to obj/item/gun)]
+ */
+/obj/item/gun/energy/laser/chameleon/proc/set_chameleon_disguise(guntype)
+	reset_chameleon_vars()
+	var/obj/item/gun/new_gun = new guntype(src)
+	set_chameleon_gun(new_gun)
+	qdel(new_gun)

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -29,6 +29,29 @@
 	select_name = "practice"
 	harmful = FALSE
 
+/obj/item/ammo_casing/energy/chameleon
+	projectile_type = /obj/projectile/energy/chameleon
+	e_cost = 0
+	var/projectile_vars = list()
+
+/obj/item/ammo_casing/energy/chameleon/ready_proj()
+	. = ..()
+
+	loaded_projectile.name = projectile_vars["name"]
+	loaded_projectile.icon = projectile_vars["icon"]
+	loaded_projectile.icon_state = projectile_vars["icon_state"]
+	loaded_projectile.speed = projectile_vars["speed"]
+	loaded_projectile.color = projectile_vars["color"]
+	loaded_projectile.hitsound = projectile_vars["hitsound"]
+	loaded_projectile.impact_effect_type = projectile_vars["impact_effect_type"]
+	loaded_projectile.range = projectile_vars["range"]
+	loaded_projectile.suppressed = projectile_vars["suppressed"]
+	loaded_projectile.hitsound_wall =	projectile_vars["hitsound_wall"]
+	loaded_projectile.pass_flags = projectile_vars["pass_flags"]
+
+	if(!loaded_projectile)
+		newshot()
+
 /obj/item/ammo_casing/energy/laser/scatter
 	projectile_type = /obj/projectile/beam/scatter
 	pellets = 5

--- a/code/modules/projectiles/projectile/energy/chameleon.dm
+++ b/code/modules/projectiles/projectile/energy/chameleon.dm
@@ -1,0 +1,2 @@
+/obj/projectile/energy/chameleon
+	nodamage = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3782,6 +3782,7 @@
 #include "code\modules\projectiles\projectile\bullets\sniper.dm"
 #include "code\modules\projectiles\projectile\bullets\special.dm"
 #include "code\modules\projectiles\projectile\energy\_energy.dm"
+#include "code\modules\projectiles\projectile\energy\chameleon.dm"
 #include "code\modules\projectiles\projectile\energy\decloner.dm"
 #include "code\modules\projectiles\projectile\energy\ebow.dm"
 #include "code\modules\projectiles\projectile\energy\net_snare.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/66569 in full. No changes from this PR. Refer to it for details.

I've opted to leave the changelog the same to properly accredit their work.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dumb, lovable gimmicks. Fake seccie? Fake operative? Who knows!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: magatsuchi for /tg/station
add: Back by popular demand, the Syndicate has re-included their state-of-the-art Chameleon Gun into their chameleon kits, capable of disguising itself as any gun known to man-kind! Lethal rounds not included.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
