### PR TITLE
Missed APCs and Air Alarms

### DIFF
--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -44568,12 +44568,12 @@
 /turf/open/floor/iron/dark,
 /area/faction/unity)
 "nYh" = (
-/obj/machinery/conveyor{
-	id = s;
-	dir = 4
-	},
 /obj/structure/window/spawner,
 /obj/effect/spawner/random/maintenance/two,
+/obj/machinery/conveyor{
+	id = "cargodisposals";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "nYm" = (

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -28025,13 +28025,10 @@
 /turf/open/floor/iron/dark/side,
 /area/engineering/engine_smes)
 "iSS" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "iTd" = (
@@ -64549,10 +64546,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uEU" = (
@@ -74465,13 +74459,6 @@
 	dir = 1
 	},
 /area/maintenance/floor3/starboard/aft)
-"xJS" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "xKa" = (
 /obj/effect/turf_decal/stripes/white/corner,
 /turf/open/floor/iron/dark/corner,
@@ -109079,7 +109066,7 @@ pay
 wXE
 dcO
 joV
-xJS
+dTm
 eeZ
 qhP
 ola

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -23,6 +23,16 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"aaw" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/starboard)
 "aax" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -4497,6 +4507,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/wardrobe/grey,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/port/fore)
 "blp" = (
@@ -4587,11 +4598,6 @@
 /obj/structure/ladder,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
-"bmo" = (
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/science/cytology/lower)
 "bmr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -7270,6 +7276,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
+"cag" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/port/aft)
 "cah" = (
 /obj/machinery/door/airlock/command{
 	name = "Unity Private Storage"
@@ -9673,6 +9686,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/surgery/fore)
+"cNA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/bronze/filled,
+/area/maintenance/floor1/starboard)
 "cNH" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -9935,16 +9953,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"cSE" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor4/port)
 "cSF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -9968,6 +9976,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/floor2/fore)
+"cSY" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/light,
+/area/service/abandoned_gambling_den)
 "cTb" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -15199,6 +15211,10 @@
 	},
 /turf/open/openspace,
 /area/maintenance/floor2/port/aft)
+"eCP" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/pod/light,
+/area/maintenance/floor3/starboard/fore)
 "eCZ" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -16494,13 +16510,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/department/medical/central)
-"fcd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor3/port)
 "fcf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18495,9 +18504,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/pumproom)
 "fNg" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/pod/light,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron/green,
+/area/service/hydroponics)
 "fNl" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -19432,11 +19441,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/lockers)
-"gdL" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/pod/light,
-/area/service/abandoned_gambling_den)
 "gec" = (
 /turf/open/floor/iron/dark/side{
 	dir = 9
@@ -21001,6 +21005,10 @@
 /obj/structure/window/spawner,
 /turf/open/floor/carpet/green,
 /area/command/heads_quarters/rd)
+"gGx" = (
+/obj/structure/cable,
+/turf/open/floor/pod/light,
+/area/service/abandoned_gambling_den)
 "gGA" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 4
@@ -21375,6 +21383,10 @@
 "gNN" = (
 /turf/open/floor/pod/dark,
 /area/maintenance/floor1/starboard)
+"gNS" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor3/port)
 "gNT" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -21639,10 +21651,10 @@
 /turf/open/floor/iron/dark/side,
 /area/engineering/storage/tech)
 "gSS" = (
-/turf/open/floor/iron/dark/red/side{
-	dir = 1
-	},
-/area/security/office)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/pod/light,
+/area/service/abandoned_gambling_den)
 "gTh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/glass/bottle/ethanol,
@@ -23550,13 +23562,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"hyr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor3/port/aft)
 "hys" = (
 /obj/structure/spider/stickyweb,
 /obj/item/chair,
@@ -23939,11 +23944,10 @@
 /turf/open/floor/iron/white,
 /area/science)
 "hED" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/red/side,
-/area/security/brig)
+/turf/open/floor/iron/dark/red/side{
+	dir = 1
+	},
+/area/security/office)
 "hEQ" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/bot_white,
@@ -25665,6 +25669,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/floor3/aft)
+"ifo" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/light,
+/area/maintenance/floor3/starboard)
 "ift" = (
 /obj/structure/closet/wardrobe/white,
 /obj/item/radio/intercom/directional/east,
@@ -28611,6 +28619,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/commons/dorms/apartment1)
+"jeD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "jeF" = (
 /obj/structure/table,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -30520,6 +30536,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/eighties/red,
 /area/commons/fitness/recreation/entertainment)
+"jJy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/red/side,
+/area/security/brig)
 "jJB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -31095,6 +31117,10 @@
 	dir = 1
 	},
 /area/engineering/atmos)
+"jUO" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/light,
+/area/maintenance/floor1/starboard/aft)
 "jUP" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
@@ -31774,10 +31800,6 @@
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/carpet/orange,
 /area/service/chapel/office)
-"ken" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor3/port)
 "kes" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32295,6 +32317,14 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor2/fore)
+"knM" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port/fore)
 "knO" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -33177,12 +33207,6 @@
 	dir = 6
 	},
 /area/hallway/floor2/aft)
-"kCf" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/hatch,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/open/floor/pod/light,
-/area/service/abandoned_gambling_den)
 "kCg" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/grass,
@@ -34594,10 +34618,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/dining)
-"kYd" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/pod/light,
-/area/maintenance/floor3/starboard/fore)
 "kYr" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron,
@@ -35297,10 +35317,6 @@
 	dir = 1
 	},
 /area/medical/chemistry)
-"lkF" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/pod/light,
-/area/service/abandoned_gambling_den)
 "lkP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -37704,6 +37720,14 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port)
+"lWR" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "lWU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -39619,6 +39643,11 @@
 	},
 /turf/open/floor/wood,
 /area/service/kitchen/diner)
+"mzk" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/light,
+/area/maintenance/oxygen_recycling)
 "mzr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -40189,6 +40218,10 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/faction/conserve_recycling)
+"mJt" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/smooth,
+/area/construction)
 "mJx" = (
 /obj/structure/rack,
 /obj/item/storage/box,
@@ -44472,16 +44505,6 @@
 /obj/item/pen/red,
 /turf/open/floor/wood/parquet,
 /area/service/lawoffice)
-"nXp" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor3/port/fore)
 "nXq" = (
 /obj/structure/chair/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -45481,11 +45504,6 @@
 /obj/effect/spawner/random/structure/table_fancy,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/aft)
-"omB" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/floor3/aft)
 "omE" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46814,6 +46832,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"oIj" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/light,
+/area/maintenance/floor3/port/fore)
 "oIr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -47850,14 +47872,6 @@
 "oZx" = (
 /turf/open/openspace,
 /area/hallway/floor3/fore)
-"oZy" = (
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/port/fore)
 "oZz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -48994,6 +49008,9 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/dark/red,
 /area/ai_monitored/security/armory)
+"pva" = (
+/turf/open/floor/iron/dark/red/side,
+/area/security/brig)
 "pvs" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
@@ -52276,6 +52293,7 @@
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/aft)
 "qAx" = (
@@ -57173,10 +57191,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"shx" = (
-/obj/structure/cable,
-/turf/open/floor/pod/light,
-/area/service/abandoned_gambling_den)
 "shz" = (
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/openspace,
@@ -58012,10 +58026,6 @@
 "swx" = (
 /turf/closed/wall,
 /area/commons/dorms/room4)
-"swF" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/pod/light,
-/area/maintenance/floor3/port/fore)
 "swL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/scrap,
@@ -58613,6 +58623,12 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/service/chapel/office)
+"sGV" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/open/floor/pod/light,
+/area/service/abandoned_gambling_den)
 "sGW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -58868,6 +58884,14 @@
 	dir = 8
 	},
 /area/hallway/floor3/fore)
+"sKO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/red/side{
+	dir = 2
+	},
+/area/security/brig)
 "sKR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
@@ -59192,10 +59216,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/range)
-"sQl" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/pod/light,
-/area/maintenance/floor3/starboard)
 "sQr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/closed/wall/r_wall,
@@ -61430,10 +61450,6 @@
 	icon_state = "damaged3"
 	},
 /area/maintenance/floor4/starboard)
-"tAY" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/smooth,
-/area/construction)
 "tBe" = (
 /obj/structure/table,
 /obj/item/storage/secure/briefcase,
@@ -61516,9 +61532,12 @@
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "tDf" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/pod/light,
-/area/maintenance/floor1/starboard/aft)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/port)
 "tDj" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -62615,9 +62634,10 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "tUn" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron/green,
-/area/service/hydroponics)
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/cytology/lower)
 "tUt" = (
 /turf/closed/wall,
 /area/commons/dorms)
@@ -63588,6 +63608,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"umR" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/pod/light,
+/area/maintenance/department/engine/atmos)
 "umY" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
@@ -68252,14 +68276,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
-"vPt" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/floor2/starboard)
 "vPu" = (
 /obj/machinery/light/red/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -68394,6 +68410,11 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"vRv" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/floor3/aft)
 "vRB" = (
 /turf/open/floor/mineral/titanium/tiled/white{
 	name = "padded floor"
@@ -69809,11 +69830,6 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor1/fore)
-"wpT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/bronze/filled,
-/area/maintenance/floor1/starboard)
 "wpV" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/structure/cable,
@@ -70720,13 +70736,15 @@
 /turf/open/floor/grass,
 /area/security/courtroom)
 "wEk" = (
+/obj/structure/railing{
+	dir = 1
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer3,
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/starboard)
+/area/maintenance/floor4/port)
 "wEo" = (
 /turf/open/floor/iron{
 	icon_state = "floorscorched1"
@@ -71361,14 +71379,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology/ward)
-"wNf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/red/side{
-	dir = 2
-	},
-/area/security/brig)
 "wNo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -72763,16 +72773,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/fore)
-"xkd" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor3/starboard)
 "xkf" = (
 /obj/effect/spawner/random/structure/crate_empty,
 /turf/open/floor/pod/light,
@@ -73614,6 +73614,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"xwI" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/port/fore)
 "xwJ" = (
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/machinery/door/airlock/hatch{
@@ -74239,6 +74249,13 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/storage)
+"xGh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor4/port)
 "xGk" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron/white,
@@ -74391,8 +74408,11 @@
 /turf/open/floor/iron,
 /area/hallway/floor3/aft)
 "xJo" = (
-/turf/open/floor/iron/dark/red/side,
-/area/security/brig)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/pod/light,
+/area/maintenance/floor4/starboard/fore)
 "xJp" = (
 /obj/item/canvas/twentyfour_twentyfour,
 /obj/structure/table,
@@ -75116,6 +75136,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/service/library/private)
 "xXv" = (
@@ -75867,6 +75888,7 @@
 	info = "Remember! Plasma is VERY flammable and even a spark can set it off.<br> Do NOT under any circumstance use this for anything other than powering the SAT.<br> Especially don't bring it near the turrets!";
 	name = "Note on Plasma"
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/storage/satellite)
 "yjG" = (
@@ -109786,7 +109808,7 @@ owI
 whV
 whV
 plf
-wpT
+cNA
 lXT
 dui
 usI
@@ -113910,7 +113932,7 @@ cEP
 kqP
 faF
 jby
-tAY
+mJt
 faF
 faF
 cjx
@@ -115454,7 +115476,7 @@ gFp
 rJX
 rJX
 bAE
-fNg
+umR
 iqa
 xgS
 iWB
@@ -125733,7 +125755,7 @@ fgA
 fgA
 juN
 mFX
-tDf
+jUO
 xnO
 glU
 xKS
@@ -163283,7 +163305,7 @@ fNT
 uXA
 lft
 hLz
-oZy
+knM
 lQI
 lQI
 lQI
@@ -170958,7 +170980,7 @@ wvg
 vnK
 kbG
 xGk
-bmo
+tUn
 vnK
 mVP
 vKx
@@ -173781,7 +173803,7 @@ vnK
 vnK
 fov
 aQV
-wEk
+jeD
 vnK
 vnK
 ihB
@@ -174299,7 +174321,7 @@ oWa
 vnK
 fmQ
 uOq
-vPt
+lWR
 vnK
 tIF
 eZN
@@ -225192,7 +225214,7 @@ ucA
 kVp
 wRJ
 wRJ
-kYd
+eCP
 klw
 klw
 aEA
@@ -227272,10 +227294,10 @@ ybQ
 eDe
 eDe
 eDe
-nXp
+xwI
 vuN
 rMc
-swF
+oIj
 gwL
 bne
 gwL
@@ -234206,9 +234228,9 @@ nCL
 lSj
 oNs
 grb
-tUn
+fNg
 sWw
-tUn
+fNg
 vcg
 mOh
 rFy
@@ -234463,7 +234485,7 @@ sNq
 rFy
 kHv
 grb
-tUn
+fNg
 sWw
 uiE
 uYg
@@ -234977,9 +234999,9 @@ sNq
 lSj
 qeA
 gAe
-tUn
+fNg
 mZy
-tUn
+fNg
 vcg
 cSf
 rFy
@@ -235234,9 +235256,9 @@ sNq
 rFy
 dPv
 grb
-tUn
+fNg
 mZy
-tUn
+fNg
 vcg
 vyH
 rFy
@@ -235748,13 +235770,13 @@ sNq
 rFy
 qUs
 grb
-tUn
+fNg
 tff
-tUn
+fNg
 vcg
-tUn
+fNg
 grb
-tUn
+fNg
 cZE
 xKJ
 xKJ
@@ -236005,13 +236027,13 @@ tQF
 rFy
 rFy
 grb
-tUn
+fNg
 tff
-tUn
+fNg
 vcg
-tUn
+fNg
 grb
-tUn
+fNg
 mFB
 xKJ
 xKJ
@@ -236024,7 +236046,7 @@ ajs
 ajs
 ajs
 tGn
-ken
+gNS
 qFr
 sxZ
 tGn
@@ -236266,9 +236288,9 @@ brO
 ruS
 umG
 yhz
-tUn
+fNg
 xmM
-tUn
+fNg
 tuH
 oYb
 nhs
@@ -237821,7 +237843,7 @@ qfT
 oZp
 ykr
 okQ
-fcd
+tDf
 aGQ
 aGQ
 ajs
@@ -243430,10 +243452,10 @@ ntf
 ntf
 ejP
 ejP
-sQl
+ifo
 ntf
 sSB
-xkd
+aaw
 lFw
 kQo
 sSB
@@ -245769,7 +245791,7 @@ rId
 sbq
 rId
 bin
-omB
+vRv
 ddg
 qtO
 ddg
@@ -249129,7 +249151,7 @@ xCb
 ebn
 ebn
 piR
-hyr
+cag
 mom
 hcT
 hcT
@@ -250669,7 +250691,7 @@ dER
 xCb
 pOn
 iYW
-gdL
+gSS
 bmi
 bmi
 bmi
@@ -250925,8 +250947,8 @@ ctd
 dQn
 xCb
 pOn
-kCf
-shx
+sGV
+gGx
 bmi
 bmi
 bmi
@@ -251440,7 +251462,7 @@ pOn
 pOn
 pOn
 iYW
-lkF
+cSY
 bmi
 bmi
 bmi
@@ -290214,7 +290236,7 @@ ucA
 ucA
 xHe
 xHe
-dGp
+xJo
 uxw
 xHe
 qhQ
@@ -301511,7 +301533,7 @@ ucA
 ldS
 ldS
 enK
-vnI
+mzk
 vnI
 ldS
 tVc
@@ -301808,7 +301830,7 @@ eBy
 sMB
 sMB
 sMB
-gSS
+hED
 akb
 ufI
 nfX
@@ -301818,7 +301840,7 @@ mdM
 mdM
 owb
 fXs
-dek
+xGh
 vPu
 fXs
 fXs
@@ -303093,7 +303115,7 @@ woK
 pnJ
 pnJ
 mDL
-gSS
+hED
 akb
 gJA
 nfX
@@ -305160,7 +305182,7 @@ fSD
 gVR
 sfM
 jbV
-cSE
+wEk
 fXs
 fXs
 ucA
@@ -307453,7 +307475,7 @@ wrj
 oWR
 hQN
 mMo
-xJo
+pva
 wrj
 uPd
 fhv
@@ -307709,8 +307731,8 @@ wDy
 wrj
 wpV
 uFw
-wNf
-hED
+sKO
+jJy
 cxg
 okJ
 bJF
@@ -307967,7 +307989,7 @@ wrj
 aJc
 hgf
 oRY
-xJo
+pva
 wrj
 vTj
 fhv
@@ -309510,7 +309532,7 @@ faM
 iuA
 wze
 bTJ
-hED
+jJy
 jze
 jsy
 gRx
@@ -309767,7 +309789,7 @@ sRH
 qIB
 eBO
 cgV
-xJo
+pva
 fgl
 sfG
 efz

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -1081,6 +1081,7 @@
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/maintenance/radshelter/sci)
 "apy" = (
@@ -4586,6 +4587,11 @@
 /obj/structure/ladder,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
+"bmo" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/cytology/lower)
 "bmr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -9929,6 +9935,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"cSE" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor4/port)
 "cSF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -10785,6 +10801,7 @@
 "dhs" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/modular_computer/laptop/preset/civilian,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/neon/simple/white,
 /area/commons/dorms/room3)
 "dhx" = (
@@ -16477,6 +16494,13 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/department/medical/central)
+"fcd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/port)
 "fcf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18471,8 +18495,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/pumproom)
 "fNg" = (
-/turf/open/floor/iron/dark/red/side,
-/area/security/brig)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/pod/light,
+/area/maintenance/department/engine/atmos)
 "fNl" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -19407,6 +19432,11 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/lockers)
+"gdL" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/pod/light,
+/area/service/abandoned_gambling_den)
 "gec" = (
 /turf/open/floor/iron/dark/side{
 	dir = 9
@@ -23520,6 +23550,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"hyr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/port/aft)
 "hys" = (
 /obj/structure/spider/stickyweb,
 /obj/item/chair,
@@ -26102,6 +26139,7 @@
 "imi" = (
 /obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/blue,
 /area/medical/cryo)
 "imj" = (
@@ -29500,6 +29538,7 @@
 "juT" = (
 /obj/structure/table/reinforced/rglass,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "juW" = (
@@ -31735,6 +31774,10 @@
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/carpet/orange,
 /area/service/chapel/office)
+"ken" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor3/port)
 "kes" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31760,6 +31803,7 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "keF" = (
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/hallway/secondary/exit/departure_lounge)
 "keL" = (
@@ -33133,6 +33177,12 @@
 	dir = 6
 	},
 /area/hallway/floor2/aft)
+"kCf" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/hatch,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/open/floor/pod/light,
+/area/service/abandoned_gambling_den)
 "kCg" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/grass,
@@ -33612,6 +33662,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/department/medical/central)
 "kKa" = (
@@ -34436,6 +34487,7 @@
 /area/ai_monitored/command/storage/eva)
 "kWd" = (
 /obj/effect/decal/cleanable/vomit/old,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
@@ -34542,6 +34594,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/dining)
+"kYd" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/pod/light,
+/area/maintenance/floor3/starboard/fore)
 "kYr" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron,
@@ -35085,6 +35141,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server/upper)
 "lhW" = (
@@ -35240,6 +35297,10 @@
 	dir = 1
 	},
 /area/medical/chemistry)
+"lkF" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/light,
+/area/service/abandoned_gambling_den)
 "lkP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -42582,6 +42643,7 @@
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "ntS" = (
@@ -44410,6 +44472,16 @@
 /obj/item/pen/red,
 /turf/open/floor/wood/parquet,
 /area/service/lawoffice)
+"nXp" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/port/fore)
 "nXq" = (
 /obj/structure/chair/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -45409,6 +45481,11 @@
 /obj/effect/spawner/random/structure/table_fancy,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/aft)
+"omB" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/floor3/aft)
 "omE" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46876,6 +46953,7 @@
 /obj/structure/rack/shelf,
 /obj/effect/spawner/random/techstorage/tcomms_all,
 /obj/effect/turf_decal/tile/yellow/full,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/storage/tech)
 "oKD" = (
@@ -47772,6 +47850,14 @@
 "oZx" = (
 /turf/open/openspace,
 /area/hallway/floor3/fore)
+"oZy" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port/fore)
 "oZz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -53055,6 +53141,7 @@
 "qNF" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/modular_computer/laptop/preset/civilian,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/red/corner{
 	dir = 4
 	},
@@ -53309,6 +53396,7 @@
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop/preset/civilian,
 /obj/item/modular_computer/laptop/preset/civilian,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/parquet,
 /area/commons/dorms/room2)
 "qQZ" = (
@@ -53559,6 +53647,7 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "qVk" = (
@@ -57084,6 +57173,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"shx" = (
+/obj/structure/cable,
+/turf/open/floor/pod/light,
+/area/service/abandoned_gambling_den)
 "shz" = (
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/openspace,
@@ -57919,6 +58012,10 @@
 "swx" = (
 /turf/closed/wall,
 /area/commons/dorms/room4)
+"swF" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/light,
+/area/maintenance/floor3/port/fore)
 "swL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/scrap,
@@ -59095,6 +59192,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/range)
+"sQl" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/light,
+/area/maintenance/floor3/starboard)
 "sQr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/closed/wall/r_wall,
@@ -61329,6 +61430,10 @@
 	icon_state = "damaged3"
 	},
 /area/maintenance/floor4/starboard)
+"tAY" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/smooth,
+/area/construction)
 "tBe" = (
 /obj/structure/table,
 /obj/item/storage/secure/briefcase,
@@ -61410,6 +61515,10 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
 /area/medical/abandoned)
+"tDf" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/pod/light,
+/area/maintenance/floor1/starboard/aft)
 "tDj" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -64817,6 +64926,7 @@
 "uLH" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop/preset/civilian,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/royalblue,
 /area/commons/dorms/room4)
 "uLO" = (
@@ -67186,6 +67296,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/service/upper)
 "vyz" = (
@@ -68141,6 +68252,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
+"vPt" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "vPu" = (
 /obj/machinery/light/red/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -69690,6 +69809,11 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor1/fore)
+"wpT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/bronze/filled,
+/area/maintenance/floor1/starboard)
 "wpV" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/structure/cable,
@@ -69766,6 +69890,7 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/light/cold/directional/west,
 /obj/effect/landmark/start/paramedic,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "wrb" = (
@@ -70595,12 +70720,13 @@
 /turf/open/floor/grass,
 /area/security/courtroom)
 "wEk" = (
-/obj/machinery/door/airlock{
-	id_tag = "miningdorm1";
-	name = "Room 1"
-	},
-/turf/open/floor/iron/smooth,
-/area/construction)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "wEo" = (
 /turf/open/floor/iron{
 	icon_state = "floorscorched1"
@@ -71235,6 +71361,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology/ward)
+"wNf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/red/side{
+	dir = 2
+	},
+/area/security/brig)
 "wNo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -72629,6 +72763,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/fore)
+"xkd" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/starboard)
 "xkf" = (
 /obj/effect/spawner/random/structure/crate_empty,
 /turf/open/floor/pod/light,
@@ -72783,6 +72927,7 @@
 /obj/effect/turf_decal/trimline/green/filled/end{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "xmQ" = (
@@ -72898,6 +73043,7 @@
 /obj/item/reagent_containers/food/drinks/britcup,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "xpk" = (
@@ -74245,12 +74391,7 @@
 /turf/open/floor/iron,
 /area/hallway/floor3/aft)
 "xJo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/red/side{
-	dir = 2
-	},
+/turf/open/floor/iron/dark/red/side,
 /area/security/brig)
 "xJp" = (
 /obj/item/canvas/twentyfour_twentyfour,
@@ -109645,7 +109786,7 @@ owI
 whV
 whV
 plf
-mST
+wpT
 lXT
 dui
 usI
@@ -112228,7 +112369,7 @@ faF
 pPP
 faF
 eqQ
-wEk
+faF
 faF
 pRY
 gBT
@@ -113769,7 +113910,7 @@ cEP
 kqP
 faF
 jby
-faF
+tAY
 faF
 faF
 cjx
@@ -115313,7 +115454,7 @@ gFp
 rJX
 rJX
 bAE
-oEM
+fNg
 iqa
 xgS
 iWB
@@ -125592,7 +125733,7 @@ fgA
 fgA
 juN
 mFX
-jFA
+tDf
 xnO
 glU
 xKS
@@ -163142,7 +163283,7 @@ fNT
 uXA
 lft
 hLz
-tal
+oZy
 lQI
 lQI
 lQI
@@ -170817,7 +170958,7 @@ wvg
 vnK
 kbG
 xGk
-eME
+bmo
 vnK
 mVP
 vKx
@@ -173640,7 +173781,7 @@ vnK
 vnK
 fov
 aQV
-oWa
+wEk
 vnK
 vnK
 ihB
@@ -174158,7 +174299,7 @@ oWa
 vnK
 fmQ
 uOq
-uOq
+vPt
 vnK
 tIF
 eZN
@@ -225051,7 +225192,7 @@ ucA
 kVp
 wRJ
 wRJ
-klw
+kYd
 klw
 klw
 aEA
@@ -227131,10 +227272,10 @@ ybQ
 eDe
 eDe
 eDe
-vuN
+nXp
 vuN
 rMc
-bne
+swF
 gwL
 bne
 gwL
@@ -235883,7 +236024,7 @@ ajs
 ajs
 ajs
 tGn
-ewY
+ken
 qFr
 sxZ
 tGn
@@ -237680,7 +237821,7 @@ qfT
 oZp
 ykr
 okQ
-pSl
+fcd
 aGQ
 aGQ
 ajs
@@ -243289,10 +243430,10 @@ ntf
 ntf
 ejP
 ejP
-ejP
+sQl
 ntf
 sSB
-dfA
+xkd
 lFw
 kQo
 sSB
@@ -245628,7 +245769,7 @@ rId
 sbq
 rId
 bin
-ddg
+omB
 ddg
 qtO
 ddg
@@ -248988,7 +249129,7 @@ xCb
 ebn
 ebn
 piR
-pOn
+hyr
 mom
 hcT
 hcT
@@ -250528,7 +250669,7 @@ dER
 xCb
 pOn
 iYW
-bmi
+gdL
 bmi
 bmi
 bmi
@@ -250784,8 +250925,8 @@ ctd
 dQn
 xCb
 pOn
-iYW
-bmi
+kCf
+shx
 bmi
 bmi
 bmi
@@ -251299,7 +251440,7 @@ pOn
 pOn
 pOn
 iYW
-bmi
+lkF
 bmi
 bmi
 bmi
@@ -305019,7 +305160,7 @@ fSD
 gVR
 sfM
 jbV
-gWN
+cSE
 fXs
 fXs
 ucA
@@ -307312,7 +307453,7 @@ wrj
 oWR
 hQN
 mMo
-fNg
+xJo
 wrj
 uPd
 fhv
@@ -307568,7 +307709,7 @@ wDy
 wrj
 wpV
 uFw
-xJo
+wNf
 hED
 cxg
 okJ
@@ -307826,7 +307967,7 @@ wrj
 aJc
 hgf
 oRY
-fNg
+xJo
 wrj
 vTj
 fhv
@@ -309626,7 +309767,7 @@ sRH
 qIB
 eBO
 cgV
-fNg
+xJo
 fgl
 sfG
 efz

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -29300,6 +29300,9 @@
 "jqo" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/south,
+/obj/machinery/conveyor_switch/oneway{
+	id = "cargodisposals"
+	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "jqv" = (
@@ -44569,7 +44572,7 @@
 /area/faction/unity)
 "nYh" = (
 /obj/machinery/conveyor{
-	id = "cargodisposals";
+	id = s;
 	dir = 4
 	},
 /obj/structure/window/spawner,


### PR DESCRIPTION
Fixes a bunch of areas not having an APC/Air Alarm. That's the PR.
:cl:
fix: A bunch of areas have now received APCs and Air Alarms, and no longer have magic power. Womp Womp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
