### PR TITLE
Fills out some of Deck 2 Central Starboard Maint

### DIFF
--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -2972,8 +2972,17 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/port/fore)
 "aQV" = (
-/obj/structure/railing/corner{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
+	},
+/obj/effect/spawner/random/structure/chair_maintenance{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
@@ -6113,6 +6122,9 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/radshelter/sci)
 "bGy" = (
@@ -7172,6 +7184,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
+"bXC" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 8
+	},
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "bYh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/ce,
@@ -8089,11 +8107,17 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "cmk" = (
-/obj/structure/railing/corner{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/pod/light,
-/area/maintenance/floor2/starboard)
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/starboard)
 "cmo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8187,6 +8211,16 @@
 	dir = 1
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
+"cnL" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "cnO" = (
 /turf/open/floor/iron/dark/side,
 /area/commons/cryo_storage)
@@ -8460,10 +8494,10 @@
 /area/security/checkpoint/first)
 "csr" = (
 /obj/structure/table/wood,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/checker,
 /area/service/kitchen/diner)
 "css" = (
@@ -8947,6 +8981,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/red,
 /area/security/office)
+"cBv" = (
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "cBx" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/crate/bin,
@@ -9080,8 +9120,14 @@
 /turf/open/floor/plating,
 /area/maintenance/floor1/starboard/fore)
 "cDq" = (
-/obj/structure/railing,
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 10
+	},
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "cDu" = (
 /obj/structure/chair/comfy/brown,
@@ -9995,7 +10041,11 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 10
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "cTP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -10361,6 +10411,21 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/project)
+"cYh" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/random/engineering/tank,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "cYn" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/dark,
@@ -10748,6 +10813,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/fore)
+"dgQ" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "dgU" = (
 /obj/structure/cable,
 /obj/machinery/light/red/directional/north,
@@ -11139,7 +11209,13 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "dnS" = (
 /obj/structure/lattice/catwalk,
@@ -11230,6 +11306,19 @@
 	name = "boxing ring"
 	},
 /area/commons/fitness)
+"dpN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 8
+	},
+/obj/machinery/shieldgen,
+/turf/open/floor/engine,
+/area/maintenance/floor2/starboard)
 "dpQ" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/dark/corner{
@@ -11417,6 +11506,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/floor4/starboard)
+"dsw" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/maintenance/floor2/starboard)
 "dsI" = (
 /obj/structure/table/reinforced/plasmarglass,
 /obj/item/food/ready_donk{
@@ -11612,6 +11709,9 @@
 	pixel_y = -8
 	},
 /obj/structure/rack/shelf,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/fore)
 "duZ" = (
@@ -13266,7 +13366,10 @@
 /area/maintenance/floor2/port/aft)
 "dUU" = (
 /obj/structure/railing/corner,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 9
+	},
+/turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "dUW" = (
 /obj/effect/turf_decal/trimline/white/arrow_ccw{
@@ -14133,6 +14236,13 @@
 /obj/structure/shuttle/engine/heater,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/aft)
+"ejr" = (
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "ejA" = (
 /obj/structure/cable,
 /obj/machinery/computer/cargo/request,
@@ -15834,6 +15944,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/faction/conserve_recycling)
+"eQD" = (
+/obj/effect/spawner/random/structure/crate,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "eQN" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/west,
@@ -16216,7 +16331,10 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 6
+	},
+/turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "eYq" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -16512,7 +16630,11 @@
 /area/command/heads_quarters/ce)
 "fcz" = (
 /obj/structure/railing,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "fcC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16536,6 +16658,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
+"fdr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "fdx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -17152,10 +17281,10 @@
 /turf/open/floor/iron/white,
 /area/hallway/floor2/aft)
 "fov" = (
-/obj/structure/railing{
+/obj/effect/spawner/structure/window/hollow/middle{
 	dir = 4
 	},
-/turf/open/floor/pod/light,
+/turf/open/floor/plating,
 /area/maintenance/floor2/starboard)
 "fow" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -17707,7 +17836,10 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "fzN" = (
 /obj/structure/cable/multilayer/multiz,
@@ -18954,6 +19086,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/floor2/fore)
+"fVk" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "fVp" = (
 /obj/structure/holosign/barrier/engineering,
 /turf/open/floor/iron/dark/smooth_large,
@@ -19117,11 +19255,11 @@
 /obj/structure/chair/sofa/left{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/checker,
 /area/service/kitchen/diner)
 "fYw" = (
@@ -19438,6 +19576,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"geb" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "gec" = (
 /turf/open/floor/iron/dark/side{
 	dir = 9
@@ -19572,6 +19719,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/floor3/aft)
+"ggg" = (
+/obj/structure/ladder,
+/obj/effect/turf_decal/trimline/purple/warning,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "ggi" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/checker,
@@ -19791,6 +19943,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/cmo)
+"gjC" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/warning,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "gjQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -20006,6 +20164,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/second)
+"gns" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "gnL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/old,
@@ -21074,7 +21239,11 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "gIo" = (
 /obj/structure/table/reinforced,
@@ -21530,10 +21699,17 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/floor4/port/aft)
 "gQA" = (
-/obj/structure/railing/corner{
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
-/turf/open/floor/pod/light,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "gQI" = (
 /obj/effect/turf_decal/siding/white{
@@ -21897,6 +22073,9 @@
 /area/maintenance/floor4/port/aft)
 "gWY" = (
 /obj/effect/spawner/random/structure/tank_holder,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/fore)
 "gXi" = (
@@ -22118,6 +22297,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/maintenance/floor2/starboard/aft)
+"hbe" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/spawner/random/engineering/canister,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "hbg" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -22513,6 +22702,14 @@
 "hgq" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
+"hgB" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "hgC" = (
 /obj/structure/mirror/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -22651,6 +22848,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
+"hjo" = (
+/obj/effect/spawner/random/structure/tank_holder,
+/obj/effect/turf_decal/trimline/purple/warning,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "hjr" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -22801,6 +23004,14 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor3/aft)
+"hlB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "hlD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -22845,11 +23056,11 @@
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/checker,
 /area/service/kitchen/diner)
 "hlY" = (
@@ -24241,6 +24452,11 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/third)
+"hJU" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "hJV" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
@@ -25380,6 +25596,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/maintenance/club)
+"iak" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "iaq" = (
 /obj/machinery/light/cold/no_nightlight/directional/north,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -25872,6 +26098,9 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Science Substation"
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth_large,
 /area/maintenance/floor2/starboard)
 "ihC" = (
@@ -26336,6 +26565,12 @@
 	dir = 1
 	},
 /area/security/office)
+"ioD" = (
+/obj/effect/turf_decal/stripes,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "ioL" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating/foam,
@@ -27885,6 +28120,15 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"iPV" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "iPX" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
@@ -27980,6 +28224,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood/large,
 /area/service/library/upper)
+"iRo" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/starboard)
 "iRr" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 10
@@ -28641,7 +28889,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/layer3,
-/obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/starboard)
 "jeF" = (
@@ -28965,7 +29213,13 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "jlS" = (
 /obj/structure/table/wood,
@@ -29075,6 +29329,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor3/starboard)
+"jmV" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 6
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "jmZ" = (
 /obj/structure/railing{
 	dir = 4
@@ -29818,6 +30081,16 @@
 /obj/machinery/portable_atmospherics/canister/tier_1,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"jxK" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "jxN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -30997,6 +31270,7 @@
 "jQG" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard)
 "jQP" = (
@@ -32452,6 +32726,13 @@
 /obj/item/multitool,
 /turf/open/floor/circuit/green/telecomms,
 /area/tcommsat/server)
+"kpt" = (
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "kpu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -34323,6 +34604,8 @@
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
 "kRS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/starboard)
 "kSa" = (
@@ -34508,6 +34791,10 @@
 	dir = 10
 	},
 /obj/structure/ladder,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "kVp" = (
@@ -34763,6 +35050,17 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/engine,
 /area/maintenance/floor1/starboard/fore)
+"lba" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 9
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "lbe" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "External Gas to Loop"
@@ -34861,6 +35159,13 @@
 /obj/item/mop,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
+"lci" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/openspace,
+/area/maintenance/floor2/starboard)
 "lcr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -35764,6 +36069,12 @@
 	name = "lab floor"
 	},
 /area/science/genetics)
+"lpB" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/floor2/starboard)
 "lpR" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -36529,6 +36840,10 @@
 	},
 /turf/open/floor/plating,
 /area/medical/surgery/fore)
+"lCR" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "lCT" = (
 /obj/machinery/light/red/directional/east,
 /turf/open/floor/pod/light,
@@ -38011,6 +38326,13 @@
 /obj/item/experi_scanner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/science/lower)
+"lZQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "lZV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/effect/turf_decal/stripes{
@@ -38478,6 +38800,12 @@
 	},
 /turf/open/floor/grass,
 /area/service/library/garden)
+"mgq" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "mgz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39815,6 +40143,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/red,
 /area/maintenance/floor2/starboard/aft)
+"mAQ" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 10
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "mAU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/pod/dark,
@@ -40614,6 +40951,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
+"mOb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "mOh" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron/green,
@@ -40884,7 +41229,6 @@
 /area/maintenance/floor1/port/fore)
 "mRQ" = (
 /obj/structure/noticeboard/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "mRV" = (
@@ -41168,8 +41512,14 @@
 /turf/open/floor/iron/dark,
 /area/service/lawoffice)
 "mWH" = (
-/obj/structure/railing/corner,
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/turf/open/floor/plating,
 /area/maintenance/floor2/starboard)
 "mWT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -41578,6 +41928,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/floor1/starboard/aft)
+"ndL" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "ndX" = (
 /obj/structure/bed{
 	dir = 4
@@ -42170,6 +42529,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/floor2/starboard)
 "nlu" = (
@@ -43282,6 +43644,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/engineering/atmos/hfr_room)
+"nCd" = (
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "nCg" = (
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/carpet/neon/simple/pink/nodots,
@@ -44125,7 +44497,6 @@
 /turf/open/floor/iron,
 /area/medical/chemistry)
 "nQG" = (
-/obj/structure/cable/multilayer/connected,
 /obj/machinery/power/smes/engineering{
 	input_attempt = 0;
 	input_level = 60000;
@@ -44134,7 +44505,8 @@
 	output_level = 60000;
 	outputting = 0
 	},
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_large,
 /area/maintenance/floor2/starboard)
 "nQH" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44276,6 +44648,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard)
 "nSx" = (
@@ -45369,6 +45744,13 @@
 	dir = 4
 	},
 /area/faction/unity)
+"ojU" = (
+/obj/structure/table/wood,
+/obj/item/clothing/suit/nerdshirt,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/floor2/starboard)
 "ojW" = (
 /obj/structure/railing{
 	dir = 8
@@ -45435,6 +45817,10 @@
 /obj/machinery/light/red/directional/north,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
+"okI" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "okJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45825,10 +46211,11 @@
 /turf/closed/wall,
 /area/commons/cryo_storage)
 "opN" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/floor2/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "opR" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/food/grown/poppy{
@@ -46933,6 +47320,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/port/fore)
+"oIo" = (
+/obj/effect/turf_decal/trimline/purple/warning,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "oIr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -48878,6 +49269,10 @@
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
 /area/science/cytology)
+"pro" = (
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "prr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49783,10 +50178,13 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "pGR" = (
+/obj/effect/spawner/random/engineering/canister,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 5
+	},
 /obj/effect/turf_decal/stripes{
 	dir = 5
 	},
-/obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/fore)
 "pGS" = (
@@ -49883,6 +50281,9 @@
 /area/commons/cryo_storage)
 "pJb" = (
 /obj/effect/spawner/random/structure/crate,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/fore)
 "pJf" = (
@@ -50096,14 +50497,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/broken/directional/east,
-/obj/item/toy/figure{
-	desc = "A model spaceship, it vaguely looks like what the Survey Wings use to fly.";
-	icon_state = "ship";
-	name = "Model Spaceship";
-	pixel_y = -5;
-	toysay = "Oxygen offline. Weapons charging. All systems nominal.";
-	toysound = 'sound/mecha/nominal.ogg'
-	},
+/obj/item/toy/figure/model_ship_non_explosive,
 /turf/open/floor/wood/large,
 /area/faction/survey_wings)
 "pNc" = (
@@ -50999,8 +51393,8 @@
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
 "qdO" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/catwalk_floor/iron_smooth,
 /area/maintenance/floor2/starboard)
 "qdS" = (
 /obj/effect/turf_decal/stripes{
@@ -51114,11 +51508,8 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space)
 "qfr" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
+/turf/open/floor/plating,
 /area/maintenance/floor1/starboard)
 "qfv" = (
 /turf/open/floor/iron/dark,
@@ -51969,7 +52360,7 @@
 	input_level = 60000;
 	output_level = 60000
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/maintenance/floor2/starboard)
 "qun" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52015,6 +52406,19 @@
 /obj/item/stack/arcadeticket,
 /turf/open/floor/eighties,
 /area/commons/fitness/recreation/entertainment)
+"qvk" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/floor2/starboard)
 "qvs" = (
 /obj/effect/turf_decal/trimline/white/arrow_cw{
 	dir = 8
@@ -53094,6 +53498,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/blue/corner,
 /area/command/heads_quarters/hop)
+"qKR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "qKY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57223,6 +57634,12 @@
 	dir = 8
 	},
 /area/faction/chiron_hq)
+"sff" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/maintenance/floor2/starboard)
 "sfv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58190,6 +58607,9 @@
 /obj/effect/spawner/random/structure/chair_maintenance{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/fore)
 "sxA" = (
@@ -58548,11 +58968,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "sDp" = (
-/obj/structure/railing{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 5
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/pod/light,
-/area/maintenance/floor1/starboard)
+/area/maintenance/floor2/starboard)
 "sDx" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -58775,7 +59196,8 @@
 /turf/open/floor/iron/dark/red,
 /area/security/checkpoint/second)
 "sHB" = (
-/obj/structure/railing{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes{
 	dir = 8
 	},
 /turf/open/floor/pod/light,
@@ -61272,6 +61694,14 @@
 /obj/machinery/light/cold/no_nightlight/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint)
+"tvB" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game,
+/obj/structure/sign/poster/contraband/pwr_game{
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/maintenance/floor2/starboard)
 "tvS" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
@@ -61815,10 +62245,8 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "tFM" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "tFY" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -62705,6 +63133,16 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
+"tTw" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "tTx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/red/directional/east,
@@ -64528,6 +64966,19 @@
 	dir = 4
 	},
 /area/command/bridge)
+"uBW" = (
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "uCl" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -65020,6 +65471,13 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor1/fore)
+"uKz" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "uKC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/firealarm/directional/north,
@@ -66121,6 +66579,14 @@
 	},
 /turf/open/floor/carpet/green,
 /area/service/kitchen/diner)
+"vaC" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "vaD" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -66773,10 +67239,13 @@
 /turf/open/floor/engine,
 /area/science/cytology/lower)
 "vlV" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 9
+	},
 /obj/effect/turf_decal/stripes{
 	dir = 9
 	},
-/obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/fore)
 "vmj" = (
@@ -66943,6 +67412,13 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/service/chapel/funeral)
+"voA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "voT" = (
 /turf/closed/wall,
 /area/maintenance/floor4/port/fore)
@@ -68202,6 +68678,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/cmo)
+"vLj" = (
+/obj/effect/spawner/random/decoration/generic,
+/obj/structure/rack,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 9
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "vLw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -68925,10 +69412,13 @@
 /turf/open/floor/wood,
 /area/service/dining)
 "vWS" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard)
 "vXc" = (
@@ -69419,6 +69909,12 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop/private)
+"wfS" = (
+/obj/effect/turf_decal/trimline/purple/warning,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "wfW" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
 	dir = 1
@@ -69485,6 +69981,16 @@
 "whD" = (
 /turf/open/floor/engine/hull,
 /area/space)
+"whL" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "whN" = (
 /obj/effect/turf_decal/stripes{
 	dir = 9
@@ -69855,10 +70361,10 @@
 /area/medical/surgery/fore)
 "wmS" = (
 /obj/structure/table/wood,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/checker,
 /area/service/kitchen/diner)
 "wmW" = (
@@ -69911,6 +70417,21 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard/fore)
+"wob" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/caution/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/maintenance/floor2/starboard)
 "woi" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
@@ -70215,6 +70736,14 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/commons/fitness)
+"wsH" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/maintenance/floor2/starboard)
 "wsN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70295,6 +70824,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"wug" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "wur" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/defibrillator/loaded,
@@ -70326,6 +70859,9 @@
 	name = "Maintenance Bulkhead"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "wuC" = (
@@ -70412,6 +70948,9 @@
 "wvR" = (
 /obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/fore)
 "wvZ" = (
@@ -71353,6 +71892,12 @@
 	name = "boxing ring"
 	},
 /area/commons/fitness)
+"wJI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "wJS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -71802,6 +72347,12 @@
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall,
 /area/maintenance/floor1/port/aft)
+"wRO" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard/fore)
 "wRQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -72169,6 +72720,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/blue/side,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"wXs" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "wXt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -72652,6 +73213,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/red,
 /area/security/checkpoint)
+"xeM" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "xeQ" = (
 /obj/machinery/mass_driver/chapelgun{
 	dir = 4
@@ -73923,6 +74495,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/faction/unity)
+"xyC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/starboard)
 "xyD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -75839,6 +76420,7 @@
 /area/maintenance/floor3/starboard)
 "yfi" = (
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard)
 "yfn" = (
@@ -110776,8 +111358,8 @@ whV
 jJm
 yfi
 wJB
-sDp
-erU
+eFY
+cmk
 lgI
 erU
 erU
@@ -111030,11 +111612,11 @@ whV
 oKS
 qKt
 whV
-jJm
+iRo
 jQG
 eFY
 qfr
-erU
+cmk
 whV
 cvW
 whV
@@ -111290,8 +111872,8 @@ whV
 jJm
 yfi
 vqN
-sDp
-erU
+eFY
+cmk
 whV
 tRj
 pjB
@@ -111548,7 +112130,7 @@ jJm
 wgo
 nSv
 vWS
-erU
+xyC
 crj
 nLk
 efr
@@ -163462,8 +164044,8 @@ sxy
 sbm
 wvR
 gWY
-qdW
-qdW
+wRO
+wRO
 pJb
 wwu
 qdW
@@ -169109,8 +169691,8 @@ wwu
 jYo
 wwu
 wwu
-qdW
-qdW
+wRO
+wRO
 xEo
 qdW
 cwq
@@ -170905,7 +171487,7 @@ ucA
 ucA
 vnK
 vnK
-wvg
+hjo
 jql
 jql
 iOA
@@ -171162,9 +171744,9 @@ ucA
 ucA
 vnK
 vnK
-wvg
+jmV
 uZg
-wvg
+vLj
 vnK
 kbG
 xGk
@@ -171420,7 +172002,7 @@ ucA
 erN
 erN
 uZg
-uZg
+lZQ
 vnK
 vnK
 owf
@@ -171676,7 +172258,7 @@ ucA
 ucA
 vnK
 vnK
-uZg
+qKR
 vnK
 vnK
 qpa
@@ -173218,7 +173800,7 @@ ucA
 ucA
 vnK
 vnK
-oWa
+jeD
 vnK
 vnK
 xxY
@@ -173476,7 +174058,7 @@ ucA
 vnK
 vnK
 oWa
-oWa
+hlB
 vnK
 vnK
 oHz
@@ -173732,7 +174314,7 @@ ucA
 ucA
 vnK
 vnK
-wvg
+mAQ
 oWa
 oWa
 oWa
@@ -173990,7 +174572,7 @@ ucA
 vnK
 vnK
 fov
-aQV
+vnK
 jeD
 vnK
 vnK
@@ -174246,8 +174828,8 @@ ucA
 ucA
 vnK
 vnK
-fvR
-tFM
+gjC
+hJU
 oWa
 vnK
 mrq
@@ -174503,9 +175085,9 @@ ucA
 ucA
 vnK
 vnK
-fvR
+oIo
 tFM
-oWa
+mOb
 vnK
 fmQ
 uOq
@@ -174760,12 +175342,12 @@ ucA
 ucA
 vnK
 vnK
-fvR
-tFM
+wfS
+ioD
 oWa
 vnK
 nlo
-fvR
+fVk
 nlo
 vnK
 vnK
@@ -175017,17 +175599,17 @@ ucA
 ucA
 vnK
 vnK
-sHB
-cmk
-oWa
-qBR
+fov
+vnK
+jeD
+vnK
 nQG
 qdO
 qtY
 vnK
-kRS
-kRS
-kRS
+dpN
+wob
+dpN
 vnK
 bsi
 nwg
@@ -175274,17 +175856,17 @@ ucA
 ucA
 vnK
 vnK
-kRS
-kRS
-kRS
+ggg
+pro
+kpt
+vnK
+vnK
+qBR
 vnK
 vnK
 vnK
+dgQ
 vnK
-vnK
-kRS
-vnK
-kRS
 vnK
 sMo
 jtC
@@ -175531,12 +176113,12 @@ ucA
 ucA
 vnK
 vnK
-kRS
-wvg
-wvg
 vnK
-kRS
-kRS
+vnK
+uBW
+nCd
+kpt
+cBv
 kRS
 kRS
 kRS
@@ -175788,17 +176370,17 @@ ucA
 ucA
 vnK
 vnK
-kRS
-wvg
-wvg
+fvR
+fvR
+fvR
+gQA
+wJI
 vnK
-kRS
-vnK
-vnK
-vnK
-vnK
-vnK
-vnK
+tTw
+cnL
+wug
+uKz
+bXC
 vnK
 qJa
 dYx
@@ -176045,16 +176627,16 @@ ucA
 ucA
 vnK
 vnK
-kRS
-kRS
-kRS
-kRS
-kRS
+fvR
+fvR
+fvR
+cYh
+wJI
 vnK
-wvg
-wvg
-mWH
-fov
+vnK
+vnK
+vnK
+jxK
 aQV
 iOA
 btX
@@ -176303,16 +176885,16 @@ ucA
 vnK
 vnK
 vnK
+mWH
 vnK
 vnK
+wJI
 vnK
-kRS
+wsH
+lpB
 vnK
-wvg
-wvg
-cDq
 wGl
-tFM
+wGl
 iOA
 aAl
 ffN
@@ -176560,16 +177142,16 @@ ucA
 ucA
 vnK
 vnK
-wvg
-wvg
-wvg
-kRS
-vnK
-wvg
-wvg
-cDq
+wJI
+voA
+wJI
+wJI
+qvk
+sff
+dsw
+erN
 wGl
-tFM
+wGl
 iOA
 ren
 rIp
@@ -176817,16 +177399,16 @@ ucA
 ucA
 vnK
 vnK
-wvg
-wvg
-wvg
-kRS
+fdr
 vnK
-wvg
-wvg
-cDq
-wGl
-tFM
+hbe
+iak
+vnK
+tvB
+ojU
+vnK
+lci
+lci
 iOA
 ocO
 frz
@@ -177072,22 +177654,22 @@ ucA
 ucA
 ucA
 ucA
-vnK
-vnK
-wvg
-wvg
-wvg
-kRS
+erN
+erN
+wJI
 vnK
 vnK
 vnK
-gQA
+vnK
+vnK
+vnK
+vnK
 sHB
 iOA
-opN
+iOA
 dZL
 btX
-dZL
+btX
 btX
 jxD
 btX
@@ -177331,10 +177913,10 @@ ucA
 ucA
 vnK
 vnK
-wvg
-wvg
-wvg
-kRS
+wJI
+ndL
+vnK
+vaC
 dUU
 dnJ
 dnJ
@@ -177588,15 +178170,15 @@ ucA
 ucA
 vnK
 vnK
-kRS
-kRS
-kRS
-kRS
+wJI
+xeM
+geb
+gns
 fcz
 wGl
 wGl
 gIa
-wvg
+lba
 iOA
 usZ
 qYM
@@ -177845,15 +178427,15 @@ ucA
 ucA
 vnK
 vnK
-kRS
-wvg
-wvg
+wJI
 vnK
-fzG
+vnK
+mgq
+iPV
 kVm
 wGl
 gIa
-wvg
+whL
 iOA
 utl
 fmV
@@ -178102,15 +178684,15 @@ ucA
 ucA
 vnK
 vnK
-kRS
-wvg
-wvg
+wJI
 vnK
-kRS
+eQD
+hgB
+sDp
 fzG
 jlJ
 eYp
-wvg
+wXs
 iOA
 aAi
 cwO
@@ -178357,11 +178939,11 @@ ucA
 ucA
 ucA
 ucA
+erN
+erN
+wJI
 vnK
-vnK
-kRS
-wvg
-wvg
+lCR
 vnK
 vnK
 vnK
@@ -178616,11 +179198,11 @@ ucA
 ucA
 vnK
 vnK
-kRS
-vnK
-vnK
+fdr
 vnK
 wvg
+wvg
+vnK
 wvg
 wvg
 vnK
@@ -178873,11 +179455,11 @@ ucA
 ucA
 vnK
 vnK
-kRS
+wJI
+okI
 wvg
 wvg
 vnK
-wvg
 wvg
 wvg
 vnK
@@ -179130,11 +179712,11 @@ ucA
 ucA
 vnK
 vnK
-kRS
-kRS
-kRS
+wJI
 wvg
-wvg
+vnK
+vnK
+vnK
 wvg
 wvg
 vnK
@@ -179387,9 +179969,9 @@ ucA
 ucA
 vnK
 vnK
+wJI
 wvg
-wvg
-kRS
+vnK
 wvg
 wvg
 wvg
@@ -179644,9 +180226,9 @@ ucA
 ucA
 vnK
 vnK
-kRS
-kRS
-kRS
+wJI
+wvg
+ejr
 wvg
 wvg
 wvg
@@ -179901,10 +180483,10 @@ ucA
 ucA
 vnK
 vnK
-kRS
-wvg
+wJI
 wvg
 vnK
+wvg
 wvg
 wvg
 wvg
@@ -180158,10 +180740,10 @@ ucA
 ucA
 vnK
 vnK
-kRS
+wJI
+wvg
 vnK
-vnK
-vnK
+wvg
 wvg
 wvg
 wvg
@@ -180415,10 +180997,10 @@ ucA
 ucA
 vnK
 vnK
-kRS
-wvg
-wvg
+wJI
+wJI
 vnK
+wvg
 wvg
 wvg
 wvg
@@ -180672,10 +181254,10 @@ ucA
 ucA
 vnK
 vnK
-kRS
-kRS
-wvg
+cDq
+wJI
 vnK
+wvg
 wvg
 wvg
 wvg
@@ -181187,7 +181769,7 @@ ucA
 dEt
 dEt
 cGu
-cGu
+opN
 dEt
 drJ
 drJ
@@ -181444,7 +182026,7 @@ ucA
 dEt
 dEt
 wWk
-cGu
+opN
 dEt
 drJ
 drJ
@@ -181701,7 +182283,7 @@ ucA
 dEt
 dEt
 cGu
-cGu
+opN
 dEt
 drJ
 drJ
@@ -181958,7 +182540,7 @@ ucA
 dEt
 dEt
 cGu
-cGu
+opN
 wuA
 mPw
 mPw
@@ -240810,10 +241392,10 @@ ucA
 ucA
 ntf
 ntf
+yfY
 ejP
 ejP
 ejP
-ntf
 sSB
 ejP
 ntf
@@ -241324,9 +241906,9 @@ ucA
 ucA
 ntf
 ntf
-ejP
-ejP
-ejP
+aVs
+aVs
+aVs
 ntf
 sSB
 sSB
@@ -241581,9 +242163,9 @@ ucA
 ucA
 ntf
 ntf
-ejP
-ejP
-ejP
+aVs
+aVs
+aVs
 ntf
 ntf
 sSB

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1624,6 +1624,11 @@
 	icon_state = "warden"
 	toysay = "Seventeen minutes for coughing at an officer!"
 
+/obj/item/toy/figure/model_ship_non_explosive // Yes, I have to specify
+	name = "\improper Model Ship"
+	icon_state = "ship"
+	toysay = "Oxygen offline. Weapons charging. All systems nominal."
+	toysound = 'sound/mecha/nominal.ogg'
 
 /obj/item/toy/dummy
 	name = "ventriloquist dummy"


### PR DESCRIPTION
(And also converts the model ship into a real subtype rather than being a snowflake map varedit)
![image](https://user-images.githubusercontent.com/50649185/182043746-b516f309-79c7-40f3-9eb2-9c0760b369c3.png)

:cl:
expansion: More has been added to Deck 2.
code: The model ship is now a subtype rather than being defined on the map itself.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
