### PR TITLE
[FUCK] Makes falsewalls blend in

### DIFF
--- a/starbloom_modules/aesthetics/walls/code/walls.dm
+++ b/starbloom_modules/aesthetics/walls/code/walls.dm
@@ -24,3 +24,10 @@
 	. = ..()
 	var/mutable_appearance/rust = mutable_appearance(icon, "rust")
 	add_overlay(rust)
+
+/obj/structure/falsewall
+	icon = 'icons/turf/walls/wall.dmi'
+	canSmoothWith = list(SMOOTH_GROUP_WALLS, SMOOTH_GROUP_WINDOW_FULLTILE, SMOOTH_GROUP_AIRLOCK)
+
+/obj/structure/falsewall/reinforced
+	icon = 'starbloom_modules/aesthetics/walls/icons/reinforced_wall.dmi'


### PR DESCRIPTION
yea

:cl:
fix: false walls use the right icons now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
