### PR TITLE
Fixes + Second Deck Maint

### DIFF
--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -1026,6 +1026,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"aoY" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "ape" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 8
@@ -2053,6 +2063,10 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor4/aft)
+"aDL" = (
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "aDQ" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -3979,6 +3993,13 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
 /area/science/robotics/mechbay)
+"bfq" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "bfs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8225,6 +8246,7 @@
 	dir = 8
 	},
 /obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "cnO" = (
@@ -10051,6 +10073,7 @@
 	dir = 10
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "cTP" = (
@@ -10604,6 +10627,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"dcY" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "dcZ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -10645,6 +10675,11 @@
 	dir = 9
 	},
 /area/faction/conserve_recycling)
+"ddC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/service/library/garden)
 "deg" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
@@ -14254,11 +14289,9 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/aft)
 "ejr" = (
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch"
-	},
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "ejA" = (
 /obj/structure/cable,
@@ -14757,6 +14790,14 @@
 "erp" = (
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor4/aft)
+"erw" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "erN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14841,6 +14882,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/floor2/starboard/aft)
+"etC" = (
+/obj/effect/spawner/structure/window/hollow/middle,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "etJ" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -15756,6 +15801,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"eKO" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "eLd" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/side{
@@ -16360,6 +16416,7 @@
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "eYq" = (
@@ -16660,6 +16717,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "fcC" = (
@@ -17865,6 +17923,7 @@
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "fzN" = (
@@ -19610,7 +19669,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/pod/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/maintenance/floor2/starboard)
 "gec" = (
 /turf/open/floor/iron/dark/side{
@@ -20196,6 +20255,7 @@
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "gnL" = (
@@ -21315,6 +21375,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/floor4/aft)
+"gJa" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "gJg" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -21761,6 +21825,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/port)
+"gQP" = (
+/obj/structure/rack/shelf,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "gQV" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -22339,6 +22407,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/engineering/canister,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "hbg" = (
@@ -22742,6 +22811,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "hgC" = (
@@ -23975,6 +24045,13 @@
 	dir = 8
 	},
 /area/medical/chemistry)
+"hzX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "hzZ" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Office"
@@ -24368,6 +24445,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/server)
+"hHz" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/spawner/random/structure/tank_holder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "hHH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -26839,6 +26922,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"isH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "isK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/grime,
@@ -27157,6 +27244,13 @@
 	dir = 1
 	},
 /area/hallway/floor4/fore)
+"iym" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 9
+	},
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "iyr" = (
 /obj/structure/table,
 /obj/item/clothing/neck/tie/red,
@@ -27375,6 +27469,16 @@
 	icon_state = "wood-broken2"
 	},
 /area/cargo/sorting)
+"iBE" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "iBF" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -28184,6 +28288,7 @@
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "iPX" = (
@@ -29282,6 +29387,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "jlS" = (
@@ -29951,6 +30057,16 @@
 /obj/machinery/defibrillator_mount/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/surgery/fore)
+"jvw" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "jvz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30228,6 +30344,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"jyO" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 10
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "jyP" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/catwalk_floor,
@@ -30464,6 +30589,10 @@
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/surgery/aft)
+"jCD" = (
+/obj/effect/spawner/structure/window/hollow/end,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "jCM" = (
 /obj/machinery/light/broken/directional/south,
 /obj/structure/fluff/paper/stack{
@@ -31373,6 +31502,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/floor3/aft)
+"jRk" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "jRq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -32339,12 +32479,21 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "kgY" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Bulkhead"
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/spawner/random/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/pod/light,
-/area/maintenance/floor2/starboard/aft)
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/screwdriver{
+	pixel_y = -3
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "kgZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/pod/dark,
@@ -36143,6 +36292,7 @@
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/maintenance/floor2/starboard)
 "lpR" = (
@@ -36816,6 +36966,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"lBo" = (
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "lBv" = (
 /obj/effect/spawner/random/structure/table,
 /turf/open/floor/plating,
@@ -36989,9 +37145,6 @@
 /turf/open/floor/wood/tile,
 /area/command/heads_quarters/captain/private)
 "lEi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/service/library/garden)
 "lEo" = (
@@ -38890,6 +39043,7 @@
 /obj/effect/turf_decal/trimline/green/warning,
 /obj/effect/turf_decal/stripes,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "mgz" = (
@@ -40402,7 +40556,6 @@
 /area/service/library/lounge)
 "mDr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/library/garden)
@@ -42034,6 +42187,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "ndX" = (
@@ -45943,7 +46097,7 @@
 /area/maintenance/floor1/port)
 "okI" = (
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "okJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49412,6 +49566,7 @@
 /area/science/cytology)
 "pro" = (
 /obj/effect/turf_decal/stripes,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "prr" = (
@@ -50751,6 +50906,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lower)
+"pOX" = (
+/obj/structure/ladder,
+/obj/structure/window,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "pPb" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -55918,6 +56078,14 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"rxX" = (
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "rxZ" = (
 /obj/item/storage/toolbox/maint_kit,
 /obj/item/ammo_casing/shotgun/improvised,
@@ -56288,6 +56456,14 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/fore)
+"rDM" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "rDQ" = (
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
@@ -56923,6 +57099,14 @@
 	initial_gas_mix = "o2=22;n2=62;water_vapor=20;TEMP=340"
 	},
 /area/maintenance/oxygen_recycling)
+"rPl" = (
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "rPq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -57788,6 +57972,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
 /area/maintenance/floor2/starboard)
 "sfv" = (
@@ -57846,6 +58031,12 @@
 	},
 /turf/open/floor/iron/textured_half,
 /area/commons/cryo_storage)
+"shc" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "shd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -59128,6 +59319,7 @@
 	dir = 5
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "sDx" = (
@@ -59356,6 +59548,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "sHJ" = (
@@ -60013,6 +60206,13 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/service/chapel/office)
+"sSy" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "sSz" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/white,
@@ -61335,6 +61535,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
+"tmz" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/starboard)
 "tmE" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -62359,6 +62562,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"tFh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/shard,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "tFm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -63605,6 +63815,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/theater/abandoned)
+"uaj" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "uam" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -64932,6 +65151,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port/fore)
+"uyx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/starboard)
 "uyD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/red/side{
@@ -65652,6 +65875,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard)
 "uKC" = (
@@ -67196,6 +67420,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/floor1/port/fore)
+"vit" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "vix" = (
 /obj/machinery/door/airlock/cmo{
 	name = "CMO Office"
@@ -70049,6 +70277,9 @@
 /obj/effect/turf_decal/arrows,
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
+"wek" = (
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "wev" = (
 /turf/closed/wall,
 /area/faction/conserve_sci)
@@ -70955,6 +71186,7 @@
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
 	},
@@ -75757,6 +75989,19 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port/fore)
+"xPR" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "xPX" = (
 /obj/machinery/light/red/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -76587,6 +76832,11 @@
 /obj/item/cigbutt,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
+"ydn" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "yef" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes,
@@ -176358,7 +176608,7 @@ vnK
 vnK
 uBW
 nCd
-kpt
+rPl
 cBv
 kRS
 kRS
@@ -178159,7 +178409,7 @@ ndL
 vnK
 vaC
 dUU
-dnJ
+xPR
 dnJ
 cTJ
 wvg
@@ -178418,7 +178668,7 @@ gns
 fcz
 wGl
 wGl
-gIa
+eKO
 lba
 iOA
 usZ
@@ -179188,7 +179438,7 @@ lCR
 vnK
 vnK
 vnK
-vnK
+iBE
 vnK
 vnK
 iOA
@@ -179441,11 +179691,11 @@ vnK
 vnK
 fdr
 vnK
-wvg
-wvg
+tmz
+rDM
 vnK
-wvg
-wvg
+ejr
+isH
 vnK
 dVf
 iOA
@@ -179698,11 +179948,11 @@ vnK
 vnK
 wJI
 okI
-wvg
-wvg
+tmz
+bfq
 vnK
-wvg
-wvg
+kgY
+isH
 vnK
 dVf
 iOA
@@ -179954,12 +180204,12 @@ ucA
 vnK
 vnK
 wJI
-wvg
+iym
 vnK
 vnK
 vnK
-wvg
-wvg
+hHz
+ydn
 vnK
 dVf
 iOA
@@ -180211,12 +180461,12 @@ ucA
 vnK
 vnK
 wJI
-wvg
+fov
 vnK
-wvg
-wvg
-wvg
-wvg
+fvR
+vnK
+jCD
+aDL
 vnK
 dVf
 dVf
@@ -180467,13 +180717,13 @@ ucA
 ucA
 vnK
 vnK
-wJI
-wvg
-ejr
-wvg
-wvg
-wvg
-wvg
+tFh
+shc
+vnK
+jvw
+sSy
+pOX
+wek
 vnK
 vnK
 vnK
@@ -180725,15 +180975,15 @@ ucA
 vnK
 vnK
 wJI
-wvg
-vnK
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
+dcY
+rxX
+vit
+uyx
+uyx
+vit
+vit
+vit
+lBo
 vnK
 dVf
 iOA
@@ -180982,15 +181232,15 @@ ucA
 vnK
 vnK
 wJI
-wvg
 vnK
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
+vnK
+erw
+uaj
+jyO
+gJa
+wug
+vit
+vnK
 vnK
 vnK
 iOA
@@ -181241,14 +181491,14 @@ vnK
 wJI
 wJI
 vnK
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
+vnK
+vnK
+vnK
+vnK
+vnK
+jRk
+vnK
+dVf
 vnK
 qiJ
 nYm
@@ -181498,14 +181748,14 @@ vnK
 cDq
 wJI
 vnK
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
-wvg
+dVf
+dVf
+dVf
+etC
+gQP
+hzX
+etC
+dVf
 vnK
 jTG
 jSh
@@ -181760,7 +182010,7 @@ vnK
 vnK
 vnK
 vnK
-vnK
+aoY
 vnK
 vnK
 vnK
@@ -182271,7 +182521,7 @@ opN
 dEt
 drJ
 drJ
-kgY
+dEt
 wgj
 wgj
 aBK
@@ -184073,7 +184323,7 @@ mPw
 dEt
 pvZ
 aqS
-mDr
+ddC
 mDr
 vss
 ojz
@@ -245749,9 +245999,9 @@ ntf
 sSB
 ntf
 ejP
+aVs
 ejP
-ejP
-ejP
+ntf
 ntf
 tLQ
 nTu
@@ -246008,7 +246258,7 @@ ntf
 ejP
 ejP
 ejP
-ejP
+yfY
 ntf
 xWr
 kYD

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -51288,7 +51288,6 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "pZi" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55025,7 +55024,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/service/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /turf/open/floor/iron/green,
 /area/service/bar)
 "rgS" = (

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -14336,6 +14336,7 @@
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "ejA" = (
@@ -15139,6 +15140,10 @@
 "ewY" = (
 /turf/open/floor/pod/dark,
 /area/maintenance/floor3/port)
+"exc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "exe" = (
 /obj/machinery/light/red/directional/north,
 /turf/open/openspace,
@@ -40309,10 +40314,6 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/iron/checker,
 /area/cargo/miningdock)
-"mwJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/maintenance/floor2/starboard/aft)
 "mwO" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/spraycan,
@@ -190004,7 +190005,7 @@ dkh
 dkh
 dEt
 dEt
-mwJ
+exc
 rvh
 bwK
 tHn

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -853,6 +853,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/engine/airless,
 /area/engineering/atmos/pumproom)
+"alH" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/port)
 "alK" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
@@ -1884,6 +1895,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"aAO" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "aAP" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -4327,6 +4342,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/port)
 "biU" = (
@@ -5534,6 +5552,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bxx" = (
@@ -5859,6 +5878,10 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/cargo/miningdock)
+"bAO" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "bAP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -6233,6 +6256,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"bHz" = (
+/obj/structure/industrial_lift{
+	id = "portmaint_lift"
+	},
+/turf/open/openspace,
+/area/maintenance/floor3/port/aft)
 "bIa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6837,6 +6866,9 @@
 /area/medical/abandoned)
 "bQV" = (
 /obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/pod/light,
@@ -8254,6 +8286,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor3/port)
 "cnx" = (
@@ -10260,6 +10295,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"cVw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "cVG" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -11232,6 +11271,13 @@
 	dir = 4
 	},
 /area/command/heads_quarters/hos)
+"dlP" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "dlR" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -11692,6 +11738,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/lockers)
+"dtV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/port)
 "dtX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -12821,6 +12874,7 @@
 	id = "hopblast";
 	name = "HoP Blast door"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "dKk" = (
@@ -14737,6 +14791,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/cargo/scrapbeacon)
+"eph" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "epj" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -14875,6 +14934,14 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/service/bar)
+"esb" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/ladder,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/maintenance/floor2/port)
 "ess" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/effect/turf_decal/trimline/white/line{
@@ -15118,6 +15185,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor3/port)
 "ewB" = (
@@ -15524,6 +15592,17 @@
 "eEQ" = (
 /turf/open/floor/iron/checker,
 /area/commons/locker)
+"eER" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing/corner,
+/obj/machinery/button/elevator{
+	id = "portmaint_lift";
+	pixel_y = -26
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "eET" = (
 /obj/structure/filingcabinet/medical,
 /turf/open/floor/iron/dark/corner,
@@ -16650,6 +16729,13 @@
 "faF" = (
 /turf/open/floor/iron/smooth,
 /area/construction)
+"faI" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 6
+	},
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "faJ" = (
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -17056,6 +17142,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass/fairy,
 /area/maintenance/club)
+"fjd" = (
+/obj/structure/foamedmetal,
+/turf/open/openspace,
+/area/maintenance/floor2/port)
 "fjk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17678,6 +17768,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"fum" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/purple/warning,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "fur" = (
 /obj/machinery/destructive_scanner,
 /turf/open/floor/iron/dark,
@@ -17689,6 +17784,13 @@
 	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/aft)
+"fuE" = (
+/obj/structure/railing,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/port)
 "fuJ" = (
 /obj/machinery/door/airlock/mining/glass,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
@@ -18053,6 +18155,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor3/port)
 "fBd" = (
@@ -18070,6 +18175,10 @@
 	dir = 6
 	},
 /area/hallway/floor1/aft)
+"fBh" = (
+/obj/structure/ladder,
+/turf/open/floor/plating/foam,
+/area/maintenance/floor1/port/aft)
 "fBk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -20043,6 +20152,10 @@
 	dir = 5
 	},
 /area/hallway/floor4/fore)
+"giI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "giM" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/kitchen,
@@ -20362,6 +20475,9 @@
 /area/faction/conserve_recycling)
 "goJ" = (
 /obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/pod/light,
@@ -20994,6 +21110,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/port)
 "gzO" = (
@@ -21857,6 +21976,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/port)
 "gPN" = (
@@ -22243,6 +22365,13 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor1/aft)
+"gWG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/port)
 "gWN" = (
 /obj/structure/railing{
 	dir = 1
@@ -22250,6 +22379,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor4/port)
 "gWO" = (
@@ -23221,6 +23353,9 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor3/aft)
+"hlu" = (
+/turf/open/floor/plating/elevatorshaft,
+/area/maintenance/floor2/port)
 "hlB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23398,6 +23533,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
+"hnZ" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "hob" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24265,7 +24405,8 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
 "hCh" = (
-/obj/machinery/light/small/directional/north,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/port)
 "hCp" = (
@@ -24628,6 +24769,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port)
 "hIS" = (
@@ -24840,6 +24984,12 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
+"hLq" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "hLs" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half,
@@ -24909,6 +25059,18 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"hLR" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor4/port)
 "hLX" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Bulkhead"
@@ -26393,6 +26555,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/port)
 "iie" = (
@@ -27793,6 +27956,16 @@
 "iFD" = (
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"iFO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/button/elevator{
+	id = "portmaint_lift";
+	pixel_y = -26
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/port/aft)
 "iGh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27872,10 +28045,8 @@
 /turf/open/floor/wood/parquet,
 /area/medical/break_room)
 "iHc" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/maintenance/floor2/port)
 "iHf" = (
 /obj/structure/table,
@@ -29272,6 +29443,12 @@
 "jgd" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"jgh" = (
+/obj/effect/spawner/structure/window/hollow/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "jgm" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cult,
@@ -29510,6 +29687,19 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/engineering/main)
+"jlz" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "jlC" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/eighties/red,
@@ -31387,6 +31577,11 @@
 	icon_state = "damaged3"
 	},
 /area/maintenance/floor4/starboard)
+"jNG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "jNL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side{
@@ -32723,6 +32918,12 @@
 /obj/machinery/light/cold/no_nightlight/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"kiI" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 5
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "kiM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -33590,6 +33791,13 @@
 /obj/item/storage/toolbox/edict,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/last_edict)
+"kxn" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/maintenance/floor2/port)
 "kxo" = (
 /turf/closed/wall/r_wall,
 /area/cargo/miningdock)
@@ -33988,6 +34196,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"kEs" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Power Generation Experimentation"
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "kEu" = (
 /obj/structure/sign/poster/contraband/atmosia_independence{
 	pixel_x = -32
@@ -34437,6 +34654,13 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"kKy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/port)
 "kKE" = (
 /obj/structure/railing{
 	dir = 8
@@ -35552,9 +35776,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
 "lcv" = (
-/obj/structure/railing/corner,
-/turf/open/floor/pod/light,
-/area/maintenance/floor3/port/aft)
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "lcF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -37083,6 +37311,7 @@
 /area/cargo/storage)
 "lzZ" = (
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
 "lAc" = (
@@ -38071,6 +38300,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/hallway/floor3/aft)
+"lPA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "lPL" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -38226,6 +38461,12 @@
 	dir = 8
 	},
 /obj/structure/ladder,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/port/aft)
 "lRi" = (
@@ -38827,8 +39068,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/last_edict)
 "mbi" = (
-/obj/structure/railing,
-/turf/open/floor/pod/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/port)
 "mbk" = (
 /obj/machinery/space_heater,
@@ -39643,6 +39887,11 @@
 	},
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
+"mnp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "mnq" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39738,6 +39987,7 @@
 /area/security/courtroom)
 "mom" = (
 /obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/port/aft)
 "moq" = (
@@ -40288,6 +40538,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/port/aft)
+"mvT" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/maintenance/floor1/port)
 "mwc" = (
 /obj/structure/chair{
 	dir = 8
@@ -40783,8 +41043,9 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "mEa" = (
-/obj/structure/railing/corner,
-/turf/closed/wall,
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/port)
 "mEg" = (
 /obj/machinery/door/firedoor,
@@ -42298,7 +42559,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/pod/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/maintenance/floor2/port)
 "ncc" = (
 /obj/structure/window/reinforced/spawner/west,
@@ -42326,6 +42587,9 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/trash/mess,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
 "ncS" = (
@@ -42854,6 +43118,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port)
 "njS" = (
@@ -43239,6 +43506,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor4/port)
 "noF" = (
@@ -43782,6 +44052,19 @@
 "nwW" = (
 /turf/open/floor/engine,
 /area/science/cytology)
+"nwX" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "nxs" = (
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
@@ -47531,6 +47814,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/port/aft)
 "oCf" = (
@@ -48298,6 +48582,12 @@
 /obj/item/folder/yellow,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard/fore)
+"oPS" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 10
+	},
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/port)
 "oPX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -48712,13 +49002,7 @@
 	},
 /area/hallway/floor1/fore)
 "oVH" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/pod/light,
+/turf/closed/wall/r_wall,
 /area/maintenance/floor2/port)
 "oVO" = (
 /obj/structure/sign/warning/vacuum,
@@ -49573,6 +49857,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/port)
 "pnf" = (
@@ -50809,12 +51094,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "pHQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/port)
 "pHT" = (
@@ -50877,6 +51162,7 @@
 "pJg" = (
 /obj/structure/railing,
 /obj/item/chair,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
 "pJi" = (
@@ -51631,6 +51917,13 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating/airless,
 /area/solars/starboard/aft)
+"pXu" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 10
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "pXL" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/corner,
@@ -51698,6 +51991,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
+"pYi" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "pYl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/blue,
@@ -53665,6 +53966,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"qDU" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 10
+	},
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "qEh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53682,6 +53990,12 @@
 	dir = 10
 	},
 /area/security/courtroom)
+"qEA" = (
+/obj/machinery/atmospherics/components/trinary/mixer,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "qEB" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -54791,6 +55105,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"qVi" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "qVk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -56525,6 +56847,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"rzQ" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/obj/effect/spawner/random/engineering/canister,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "rzW" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -57024,6 +57353,12 @@
 	},
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/port/aft)
@@ -57670,6 +58005,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/port/aft)
 "rTw" = (
@@ -57828,6 +58166,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side,
 /area/security/office)
+"rWb" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/port)
 "rWo" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/pod/light,
@@ -58514,7 +58865,6 @@
 /area/maintenance/floor1/starboard/fore)
 "slk" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/floor2/port/aft)
 "sln" = (
@@ -59118,6 +59468,18 @@
 "suX" = (
 /turf/closed/wall/r_wall,
 /area/faction/homeguard)
+"svi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "svm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -60436,6 +60798,13 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
+"sPY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "sQa" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -60557,6 +60926,11 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
+"sSi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "sSl" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -61200,6 +61574,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"sZP" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "sZT" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor/border_only{
@@ -61828,6 +62210,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor4/port)
 "tkU" = (
@@ -62267,8 +62653,10 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor4/port/fore)
 "trY" = (
-/obj/structure/ladder,
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/port)
 "trZ" = (
 /obj/machinery/door/airlock/command{
@@ -62786,6 +63174,11 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark/red/side,
 /area/security/prison)
+"tBl" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/pod/light,
+/area/maintenance/floor3/port/aft)
 "tBp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -62793,6 +63186,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/engineering/break_room)
+"tBu" = (
+/obj/structure/grille,
+/obj/structure/closet/emcloset,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/port/fore)
 "tBv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -63196,6 +63594,7 @@
 "tIj" = (
 /obj/structure/railing,
 /obj/structure/chair,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
 "tIl" = (
@@ -64566,6 +64965,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/lower)
+"ufx" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "ufA" = (
 /obj/structure/table/rolling,
 /obj/item/storage/backpack/duffelbag/med/surgery{
@@ -64649,6 +65053,14 @@
 	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
+"ugc" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "ugr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/firealarm/directional/west,
@@ -64834,6 +65246,19 @@
 /obj/structure/stairs/east,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
+"ujm" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "ujo" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -65538,6 +65963,15 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/theater)
+"uxn" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/port)
 "uxt" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -65738,11 +66172,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "uAe" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/pod/light,
-/area/maintenance/floor3/port/aft)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port/aft)
 "uAk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68736,6 +69169,13 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plating/airless,
 /area/solars/port/fore)
+"vvU" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "vvW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -69216,6 +69656,9 @@
 	dir = 1
 	},
 /obj/effect/spawner/random/structure/grille,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
 "vEw" = (
@@ -70969,6 +71412,13 @@
 	},
 /turf/open/floor/pod/dark,
 /area/maintenance/floor3/port/fore)
+"wiE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "wiH" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
@@ -72418,6 +72868,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor4/port)
 "wEo" = (
@@ -73082,6 +73535,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor3/port)
 "wNL" = (
@@ -73276,6 +73732,13 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor3/fore)
+"wRu" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 4
+	},
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "wRx" = (
 /obj/machinery/vending/wallmed/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -74449,7 +74912,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/pod/dark,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/maintenance/floor2/port/aft)
 "xiL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -75578,6 +76041,13 @@
 	dir = 4
 	},
 /area/hallway/floor2/fore)
+"xAj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "xAl" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -76016,6 +76486,13 @@
 "xGl" = (
 /turf/open/floor/plating/foam,
 /area/maintenance/floor1/port/aft)
+"xGs" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 10
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "xGx" = (
 /obj/structure/window/reinforced/fulltile/ec_glass{
 	id = "law_ec"
@@ -76436,6 +76913,9 @@
 	dir = 8
 	},
 /obj/effect/spawner/random/structure/grille,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
 "xOy" = (
@@ -76575,6 +77055,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/port)
 "xRb" = (
@@ -110116,7 +110597,7 @@ cFr
 kzE
 twx
 twx
-fvE
+fuE
 xfT
 rYa
 xfT
@@ -110373,7 +110854,7 @@ cFr
 kzE
 bMz
 eOY
-fvE
+fuE
 xfT
 xrB
 xfT
@@ -110630,7 +111111,7 @@ kET
 kzE
 twx
 oTc
-fvE
+fuE
 xfT
 xfT
 xfT
@@ -110887,10 +111368,10 @@ cFr
 kzE
 gbh
 twx
-nWf
-ema
-ema
-ema
+uxn
+alH
+alH
+alH
 sat
 xgH
 xgH
@@ -116028,8 +116509,8 @@ hdA
 uLj
 bQV
 bQV
-xee
-xee
+mvT
+mvT
 rfz
 xgH
 xgH
@@ -117569,7 +118050,7 @@ xgH
 hdA
 hdA
 hdA
-hdA
+dtV
 hdA
 hdA
 bpE
@@ -121681,7 +122162,7 @@ dEc
 nJt
 nJt
 nJt
-xGl
+fBh
 mrs
 riT
 cll
@@ -170249,7 +170730,7 @@ hLz
 hLz
 hLz
 hLz
-xvz
+tBu
 uXA
 hLz
 hZP
@@ -172571,7 +173052,7 @@ ajq
 aal
 aal
 aal
-kJD
+nwX
 aal
 aal
 aal
@@ -172827,8 +173308,8 @@ eOv
 rQX
 aal
 hCh
-tdh
-nca
+cVw
+gWG
 xQG
 aal
 aal
@@ -173084,9 +173565,9 @@ eOv
 bbg
 aal
 aal
-aal
-kJD
-aal
+mEa
+gWG
+ufx
 aal
 aal
 ucA
@@ -173340,10 +173821,10 @@ xQo
 eOv
 bbg
 aal
-xtQ
-cda
-ybG
-lfy
+hLq
+jNG
+kKy
+cVw
 aal
 aal
 ucA
@@ -173597,10 +174078,10 @@ wkm
 eOv
 tQu
 aal
-lfy
-lfy
-ybG
-lfy
+aal
+aal
+ujm
+aal
 aal
 aal
 ucA
@@ -175913,7 +176394,7 @@ aal
 hAg
 lrA
 hAg
-biS
+jlz
 aal
 aal
 ucA
@@ -181051,7 +181532,7 @@ feM
 feM
 vwv
 aal
-ybG
+xAj
 nPo
 aal
 aal
@@ -181308,8 +181789,8 @@ aal
 aal
 aal
 aal
-ybG
-nPo
+sPY
+aal
 aal
 aal
 ucA
@@ -181567,8 +182048,8 @@ ybG
 ybG
 ybG
 ybG
-aal
-aal
+iHc
+iHc
 ucA
 ucA
 ucA
@@ -182852,8 +183333,8 @@ ybG
 ybG
 ybG
 ybG
-aal
-aal
+iHc
+iHc
 ucA
 ucA
 ucA
@@ -183106,9 +183587,9 @@ aal
 aal
 aal
 xkn
-mEa
-iHc
-iHc
+aal
+aal
+aal
 aal
 aal
 ucA
@@ -183349,7 +183830,7 @@ wFq
 hoj
 lsQ
 aal
-nRm
+rzQ
 aal
 aal
 uNB
@@ -183360,12 +183841,12 @@ aal
 aal
 aal
 aal
-nRm
-nRm
+sSi
+aal
 ybG
 mbi
-lfy
-lfy
+hlu
+hlu
 aal
 aal
 ucA
@@ -183608,21 +184089,21 @@ cqh
 vff
 ybG
 ybG
+bAO
+ybG
+ybG
+ybG
+kiI
+dlP
+wRu
 aal
-ybG
-ybG
-ybG
-nRm
-nRm
-nRm
+sSi
+sSi
 aal
-nRm
-nRm
-nRm
-ybG
+qDU
 mbi
-lfy
-lfy
+hlu
+hlu
 aal
 aal
 ucA
@@ -183863,23 +184344,23 @@ wGg
 jZS
 sFQ
 aal
-nRm
+oPS
 ybG
 ybG
 ybG
+jgh
+ybG
+ybG
+ybG
+kiI
 aal
-ybG
-ybG
-ybG
-nRm
 aal
-nRm
-ybG
-ybG
-ybG
-mbi
-lfy
-lfy
+aal
+aal
+faI
+eER
+aal
+aal
 aal
 aal
 ucA
@@ -184126,15 +184607,15 @@ aal
 aal
 aal
 aal
-nRm
+pXu
 ybG
 ybG
 ybG
 ybG
 ybG
-nRm
 ybG
-mbi
+ybG
+pnc
 lfy
 lfy
 aal
@@ -184383,15 +184864,15 @@ bif
 fSi
 bnI
 aal
-nRm
+fum
 ybG
 aal
 aal
 aal
 aal
 trY
-ybG
-mbi
+xGs
+pnc
 lfy
 lfy
 aal
@@ -184646,11 +185127,11 @@ aal
 bzD
 bzD
 aal
-nRm
-ybG
+vae
+aal
 iid
-oVH
-oVH
+aal
+aal
 aal
 aal
 ucA
@@ -186187,12 +186668,12 @@ bsK
 bxr
 bzY
 aal
-ybG
-ybG
-ybG
+sSi
+sSi
+aal
 pHQ
-gzw
-gzw
+svi
+svi
 aal
 aal
 ucA
@@ -186443,13 +186924,13 @@ kqL
 btW
 bxZ
 bAc
-aal
-ybG
-aal
-aal
-aal
-aal
-aal
+oVH
+oVH
+oVH
+oVH
+hnZ
+oVH
+xAj
 aal
 aal
 ucA
@@ -186699,16 +187180,16 @@ brC
 ltt
 jXc
 byj
-aal
-aal
+oVH
+oVH
+hAg
+hAg
+kxn
+wiE
+hnZ
 ybG
-ybG
-ybG
-ybG
-ybG
-nRm
-aal
-aal
+iHc
+iHc
 ucA
 ucA
 ucA
@@ -186956,14 +187437,14 @@ oZj
 jkH
 jXc
 aVg
-aal
-nRm
-ybG
-aal
-ybG
-aal
-ybG
-nRm
+oVH
+fjd
+hAg
+hAg
+kxn
+wiE
+hnZ
+mnp
 aal
 aal
 ucA
@@ -187213,14 +187694,14 @@ iaC
 oZc
 jXc
 tch
-aal
-nRm
+oVH
+fjd
+fjd
+hAg
+esb
+lPA
+hnZ
 ybG
-aal
-ybG
-nRm
-ybG
-nRm
 aal
 aal
 ucA
@@ -187470,14 +187951,14 @@ bfs
 cVT
 jXc
 byx
-aal
-aal
+oVH
+oVH
+aAO
+aAO
+oVH
+kEs
+oVH
 ybG
-aal
-ybG
-aal
-ybG
-nRm
 aal
 aal
 ucA
@@ -187728,13 +188209,13 @@ kqL
 btW
 byH
 bAj
-aal
+oVH
+sZP
+giI
+lfy
+vvU
+oVH
 ybG
-aal
-ybG
-nRm
-ybG
-nRm
 aal
 aal
 ucA
@@ -187970,13 +188451,13 @@ hgq
 xYM
 kzK
 qYb
-tPm
-tPm
-tPm
-tPm
-tPm
-tPm
-tPm
+nlN
+nlN
+nlN
+nlN
+nlN
+nlN
+nlN
 bnf
 fOk
 bpL
@@ -187985,13 +188466,13 @@ btt
 opr
 byI
 bAn
-aal
+oVH
+qVi
+ugc
+lcv
+giI
+oVH
 ybG
-aal
-ybG
-aal
-ybG
-nRm
 aal
 aal
 ucA
@@ -188232,9 +188713,7 @@ xui
 dEJ
 xui
 slk
-gSu
-tPm
-tPm
+uAe
 nlN
 nlN
 nlN
@@ -188243,11 +188722,13 @@ nlN
 nlN
 nlN
 nlN
-ybG
-ybG
-ybG
-nRm
-ybG
+nlN
+oVH
+pYi
+eph
+qEA
+ugc
+oVH
 ybG
 aal
 aal
@@ -188488,10 +188969,10 @@ tPm
 tPm
 tPm
 xui
-tPm
-gSu
-gSu
-tPm
+nlN
+uAe
+uAe
+nlN
 pEp
 pEp
 pEp
@@ -188499,15 +188980,15 @@ pEp
 gwT
 pPG
 nlN
-nlN
-nlN
-nlN
-nlN
-nlN
-nlN
+oVH
+oVH
+oVH
+oVH
+oVH
+oVH
 ybG
-aal
-aal
+iHc
+iHc
 ucA
 ucA
 ucA
@@ -188745,10 +189226,10 @@ tPm
 gSu
 tPm
 xui
-tPm
-tPm
-tPm
-tPm
+nlN
+nlN
+nlN
+nlN
 vJs
 pEp
 pEp
@@ -238879,7 +239360,7 @@ ajs
 ajs
 ajs
 pSl
-aGQ
+ajs
 tGn
 tGn
 ucA
@@ -239133,10 +239614,10 @@ oZp
 awo
 tGn
 ajs
-aGQ
-aGQ
+ajs
+ajs
 pSl
-aGQ
+ajs
 tGn
 tGn
 ucA
@@ -241961,7 +242442,7 @@ tGn
 ajs
 vKw
 wNH
-wNH
+rWb
 wNH
 geL
 tGn
@@ -248384,10 +248865,10 @@ ebn
 ebn
 ebn
 ebn
-piR
-piR
-piR
-piR
+ebn
+ebn
+ebn
+ebn
 piR
 piR
 ucA
@@ -248642,9 +249123,9 @@ piR
 piR
 piR
 piR
-lcv
-uAe
-uAe
+piR
+piR
+piR
 piR
 piR
 ucA
@@ -248899,9 +249380,9 @@ pOn
 pOn
 pOn
 pOn
-mom
-hcT
-hcT
+tBl
+bHz
+bHz
 piR
 piR
 ucA
@@ -249156,9 +249637,9 @@ piR
 piR
 piR
 pOn
-mom
-hcT
-hcT
+tBl
+bHz
+bHz
 piR
 piR
 ucA
@@ -249412,10 +249893,10 @@ piR
 pOn
 pOn
 pOn
-pOn
-mom
-hcT
-hcT
+iFO
+piR
+piR
+piR
 piR
 piR
 ucA
@@ -249925,7 +250406,7 @@ leY
 piR
 pOn
 piR
-qeX
+ebn
 pOn
 mom
 hcT
@@ -250182,7 +250663,7 @@ prQ
 piR
 pOn
 piR
-ebn
+qeX
 pOn
 nko
 rIY
@@ -306469,8 +306950,8 @@ fSD
 sPs
 vEa
 tkM
-tkM
-tkM
+hLR
+hLR
 pze
 fXs
 fXs

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -40309,6 +40309,10 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/iron/checker,
 /area/cargo/miningdock)
+"mwJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "mwO" = (
 /obj/structure/table/wood,
 /obj/item/toy/crayon/spraycan,
@@ -190000,7 +190004,7 @@ dkh
 dkh
 dEt
 dEt
-fXq
+mwJ
 rvh
 bwK
 tHn

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -1026,16 +1026,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"aoY" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Bulkhead"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "ape" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 8
@@ -2063,10 +2053,6 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor4/aft)
-"aDL" = (
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "aDQ" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -2098,6 +2084,13 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor1/fore)
+"aEl" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "aEm" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -2934,6 +2927,13 @@
 	dir = 1
 	},
 /area/commons/cryo_storage)
+"aPP" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "aQk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 2
@@ -3993,13 +3993,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/dark/smooth_large,
 /area/science/robotics/mechbay)
-"bfq" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "bfs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4942,6 +4935,17 @@
 	dir = 8
 	},
 /area/science/robotics/lab)
+"bqi" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "bqu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
@@ -7207,6 +7211,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
+"bXx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/library/garden)
 "bXC" = (
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 8
@@ -7670,6 +7679,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/pumproom)
+"cfp" = (
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "cfu" = (
 /obj/structure/railing{
 	dir = 1
@@ -9757,6 +9770,11 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/service/chapel/funeral)
+"cNJ" = (
+/obj/structure/ladder,
+/obj/structure/window,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "cNP" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/machinery/camera/motion/directional/south,
@@ -10173,6 +10191,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
+"cUS" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 9
+	},
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "cUY" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -10572,6 +10597,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"dai" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "daF" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
@@ -10627,13 +10662,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"dcY" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "dcZ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -10675,11 +10703,6 @@
 	dir = 9
 	},
 /area/faction/conserve_recycling)
-"ddC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/garden)
 "deg" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
@@ -11367,6 +11390,17 @@
 	dir = 4
 	},
 /area/service/lawoffice)
+"dpW" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "dqm" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood/random,
@@ -13522,6 +13556,9 @@
 /obj/item/hand_tele,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
+"dWA" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/starboard)
 "dWJ" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -14289,8 +14326,13 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/starboard/aft)
 "ejr" = (
-/obj/effect/turf_decal/trimline/green/warning,
-/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "ejA" = (
@@ -14790,14 +14832,6 @@
 "erp" = (
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor4/aft)
-"erw" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "erN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14882,10 +14916,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/floor2/starboard/aft)
-"etC" = (
-/obj/effect/spawner/structure/window/hollow/middle,
-/turf/open/floor/plating,
-/area/maintenance/floor2/starboard)
 "etJ" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -15376,6 +15406,16 @@
 "eDe" = (
 /turf/closed/wall,
 /area/hallway/floor3/fore)
+"eDt" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "eDu" = (
 /obj/effect/turf_decal/stripes{
 	dir = 10
@@ -15801,17 +15841,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"eKO" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/warning,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/light,
-/area/maintenance/floor2/starboard)
 "eLd" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/side{
@@ -17086,6 +17115,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
+"fke" = (
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "fkf" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
@@ -17311,6 +17346,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/floor3/fore)
+"fnp" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/spawner/random/structure/tank_holder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "fnA" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/turf_decal/siding/blue/corner,
@@ -17463,6 +17504,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/maintenance/floor4/port/aft)
+"fqd" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "fqg" = (
 /obj/structure/railing{
 	dir = 8
@@ -17491,6 +17541,11 @@
 	},
 /turf/open/floor/iron,
 /area/commons/cryo_storage)
+"fqM" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "frz" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/structure/rack,
@@ -20766,6 +20821,10 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron/dark,
 /area/maintenance/floor2/starboard/aft)
+"gxj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "gxn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21375,10 +21434,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/floor4/aft)
-"gJa" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "gJg" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -21676,6 +21731,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"gOb" = (
+/obj/effect/spawner/structure/window/hollow/end,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "gOd" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname/directional/west,
@@ -21825,10 +21884,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/port)
-"gQP" = (
-/obj/structure/rack/shelf,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "gQV" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -23587,6 +23642,17 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
+"hty" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "htG" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Bulkhead"
@@ -24045,13 +24111,6 @@
 	dir = 8
 	},
 /area/medical/chemistry)
-"hzX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "hzZ" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Office"
@@ -24445,12 +24504,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/server)
-"hHz" = (
-/obj/effect/turf_decal/trimline/green/warning,
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "hHH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -26184,6 +26237,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
+"ihb" = (
+/obj/effect/spawner/structure/window/hollow/middle,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "ihd" = (
 /obj/machinery/computer/atmos_control/mix_tank,
 /obj/structure/window/reinforced/spawner/north,
@@ -26922,10 +26979,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"isH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "isK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/grime,
@@ -27244,13 +27297,6 @@
 	dir = 1
 	},
 /area/hallway/floor4/fore)
-"iym" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 9
-	},
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "iyr" = (
 /obj/structure/table,
 /obj/item/clothing/neck/tie/red,
@@ -27469,16 +27515,6 @@
 	icon_state = "wood-broken2"
 	},
 /area/cargo/sorting)
-"iBE" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "iBF" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -30057,16 +30093,6 @@
 /obj/machinery/defibrillator_mount/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/surgery/fore)
-"jvw" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "jvz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30344,15 +30370,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"jyO" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 10
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/emcloset,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "jyP" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/catwalk_floor,
@@ -30589,10 +30606,6 @@
 /obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/surgery/aft)
-"jCD" = (
-/obj/effect/spawner/structure/window/hollow/end,
-/turf/open/floor/plating,
-/area/maintenance/floor2/starboard)
 "jCM" = (
 /obj/machinery/light/broken/directional/south,
 /obj/structure/fluff/paper/stack{
@@ -31502,17 +31515,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/floor3/aft)
-"jRk" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Bulkhead"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "jRq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -32479,19 +32481,7 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "kgY" = (
-/obj/effect/turf_decal/trimline/green/warning,
-/obj/effect/spawner/random/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/screwdriver{
-	pixel_y = -3
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "kgZ" = (
@@ -32958,6 +32948,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/cargo/scrapbeacon)
+"kpw" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "kpx" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -35820,6 +35818,10 @@
 /obj/item/reagent_containers/glass/bowl/mushroom_bowl,
 /turf/open/floor/noslip,
 /area/maintenance/floor1/port)
+"ljp" = (
+/obj/structure/rack/shelf,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "ljs" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/camera/directional/east{
@@ -36966,12 +36968,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"lBo" = (
-/obj/effect/spawner/structure/window/hollow/directional{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/floor2/starboard)
 "lBv" = (
 /obj/effect/spawner/random/structure/table,
 /turf/open/floor/plating,
@@ -40556,7 +40552,7 @@
 /area/service/library/lounge)
 "mDr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/library/garden)
 "mDL" = (
@@ -46097,6 +46093,7 @@
 /area/maintenance/floor1/port)
 "okI" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "okJ" = (
@@ -49056,6 +49053,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"piJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "piO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49134,6 +49136,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
+"pkH" = (
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "pkI" = (
 /obj/structure/railing{
 	dir = 6
@@ -50906,11 +50911,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/lower)
-"pOX" = (
-/obj/structure/ladder,
-/obj/structure/window,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "pPb" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -51337,6 +51337,16 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating/airless,
 /area/solars/starboard/aft)
+"pXs" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 10
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "pXL" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/corner,
@@ -52665,6 +52675,22 @@
 	output_level = 60000
 	},
 /turf/open/floor/iron/smooth_large,
+/area/maintenance/floor2/starboard)
+"qug" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/spawner/random/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/screwdriver{
+	pixel_y = -3
+	},
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "qun" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54339,6 +54365,11 @@
 /obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plating,
 /area/maintenance/floor1/port/fore)
+"qSZ" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "qTd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -56078,14 +56109,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"rxX" = (
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "rxZ" = (
 /obj/item/storage/toolbox/maint_kit,
 /obj/item/ammo_casing/shotgun/improvised,
@@ -56456,14 +56479,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/fore)
-"rDM" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "rDQ" = (
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
@@ -57099,14 +57114,6 @@
 	initial_gas_mix = "o2=22;n2=62;water_vapor=20;TEMP=340"
 	},
 /area/maintenance/oxygen_recycling)
-"rPl" = (
-/obj/structure/cable/layer3,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/starboard)
 "rPq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -58031,12 +58038,6 @@
 	},
 /turf/open/floor/iron/textured_half,
 /area/commons/cryo_storage)
-"shc" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "shd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -58181,6 +58182,14 @@
 	dir = 4
 	},
 /area/security/prison)
+"skQ" = (
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "skU" = (
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -60206,13 +60215,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/service/chapel/office)
-"sSy" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "sSz" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/white,
@@ -60336,6 +60338,11 @@
 	},
 /turf/open/floor/iron,
 /area/service/library/lounge)
+"sTX" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "sTZ" = (
 /turf/open/floor/wood,
 /area/service/theater)
@@ -60526,6 +60533,10 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"sWb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/starboard)
 "sWh" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
@@ -61003,6 +61014,19 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/floor3/fore)
+"tcH" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "tcJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bot_assembly/medbot,
@@ -61535,9 +61559,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
-"tmz" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/maintenance/floor2/starboard)
 "tmE" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -62562,13 +62583,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"tFh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/shard,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/starboard)
 "tFm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -63758,6 +63772,14 @@
 	dir = 1
 	},
 /area/medical/surgery/aft)
+"tYR" = (
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "tYU" = (
 /obj/structure/sink{
 	pixel_y = 22
@@ -63815,15 +63837,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/theater/abandoned)
-"uaj" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "uam" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -65151,10 +65164,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port/fore)
-"uyx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/maintenance/floor2/starboard)
 "uyD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/red/side{
@@ -65922,6 +65931,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"uLh" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "uLj" = (
 /obj/structure/railing/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -66875,6 +66891,13 @@
 	dir = 8
 	},
 /area/security/office)
+"uYO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "uYT" = (
 /obj/structure/window/plasma/spawner/north,
 /obj/structure/window/plasma/spawner/west,
@@ -67420,10 +67443,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/floor1/port/fore)
-"vit" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "vix" = (
 /obj/machinery/door/airlock/cmo{
 	name = "CMO Office"
@@ -69154,6 +69173,13 @@
 /obj/item/seeds/cannabis,
 /turf/open/floor/iron,
 /area/maintenance/floor1/port/aft)
+"vMH" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "vMK" = (
 /obj/machinery/atmospherics/components/binary/crystallizer{
 	dir = 4
@@ -70277,9 +70303,6 @@
 /obj/effect/turf_decal/arrows,
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
-"wek" = (
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "wev" = (
 /turf/closed/wall,
 /area/faction/conserve_sci)
@@ -71791,6 +71814,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/chapel)
+"wCa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/shard,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "wCb" = (
 /obj/structure/window/reinforced/fulltile/ec_glass{
 	id = "orprivacy_b"
@@ -75989,19 +76019,6 @@
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port/fore)
-"xPR" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/light,
-/area/maintenance/floor2/starboard)
 "xPX" = (
 /obj/machinery/light/red/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -76832,11 +76849,6 @@
 /obj/item/cigbutt,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
-"ydn" = (
-/obj/item/stack/cable_coil/cut,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "yef" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes,
@@ -176608,7 +176620,7 @@ vnK
 vnK
 uBW
 nCd
-rPl
+tYR
 cBv
 kRS
 kRS
@@ -178409,7 +178421,7 @@ ndL
 vnK
 vaC
 dUU
-xPR
+tcH
 dnJ
 cTJ
 wvg
@@ -178668,7 +178680,7 @@ gns
 fcz
 wGl
 wGl
-eKO
+bqi
 lba
 iOA
 usZ
@@ -179438,7 +179450,7 @@ lCR
 vnK
 vnK
 vnK
-iBE
+eDt
 vnK
 vnK
 iOA
@@ -179691,11 +179703,11 @@ vnK
 vnK
 fdr
 vnK
-tmz
-rDM
+dWA
+kpw
 vnK
-ejr
-isH
+sTX
+kgY
 vnK
 dVf
 iOA
@@ -179948,11 +179960,11 @@ vnK
 vnK
 wJI
 okI
-tmz
-bfq
+dWA
+uLh
 vnK
+qug
 kgY
-isH
 vnK
 dVf
 iOA
@@ -180204,12 +180216,12 @@ ucA
 vnK
 vnK
 wJI
-iym
+cUS
 vnK
 vnK
 vnK
-hHz
-ydn
+fnp
+fqM
 vnK
 dVf
 iOA
@@ -180465,8 +180477,8 @@ fov
 vnK
 fvR
 vnK
-jCD
-aDL
+gOb
+cfp
 vnK
 dVf
 dVf
@@ -180717,13 +180729,13 @@ ucA
 ucA
 vnK
 vnK
-tFh
-shc
+wCa
+vMH
 vnK
-jvw
-sSy
-pOX
-wek
+dpW
+aEl
+cNJ
+pkH
 vnK
 vnK
 vnK
@@ -180975,15 +180987,15 @@ ucA
 vnK
 vnK
 wJI
-dcY
-rxX
-vit
-uyx
-uyx
-vit
-vit
-vit
-lBo
+aPP
+skQ
+piJ
+sWb
+sWb
+piJ
+piJ
+gxj
+fke
 vnK
 dVf
 iOA
@@ -181234,12 +181246,12 @@ vnK
 wJI
 vnK
 vnK
-erw
-uaj
-jyO
-gJa
+fqd
+ejr
+pXs
+qSZ
 wug
-vit
+piJ
 vnK
 vnK
 vnK
@@ -181496,7 +181508,7 @@ vnK
 vnK
 vnK
 vnK
-jRk
+hty
 vnK
 dVf
 vnK
@@ -181751,10 +181763,10 @@ vnK
 dVf
 dVf
 dVf
-etC
-gQP
-hzX
-etC
+ihb
+ljp
+uYO
+ihb
 dVf
 vnK
 jTG
@@ -182010,7 +182022,7 @@ vnK
 vnK
 vnK
 vnK
-aoY
+dai
 vnK
 vnK
 vnK
@@ -184323,8 +184335,8 @@ mPw
 dEt
 pvZ
 aqS
-ddC
 mDr
+bXx
 vss
 ojz
 mcB

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -320,6 +320,13 @@
 /obj/structure/grille,
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor1/fore)
+"adq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/port)
 "adw" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/airlock/atmos{
@@ -853,17 +860,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber,
 /turf/open/floor/engine/airless,
 /area/engineering/atmos/pumproom)
-"alH" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor1/port)
 "alK" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
@@ -1293,6 +1289,15 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
+"asf" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/port)
 "asg" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -1589,6 +1594,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/fore)
+"awN" = (
+/obj/structure/grille,
+/obj/structure/closet/emcloset,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/port/fore)
 "awT" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/window/spawner/west,
@@ -1895,9 +1905,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"aAO" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
+"aAK" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/purple/warning,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/port)
 "aAP" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -4345,6 +4356,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/port)
 "biU" = (
@@ -5878,10 +5890,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/cargo/miningdock)
-"bAO" = (
-/obj/effect/spawner/random/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "bAP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -6256,12 +6264,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"bHz" = (
-/obj/structure/industrial_lift{
-	id = "portmaint_lift"
-	},
-/turf/open/openspace,
-/area/maintenance/floor3/port/aft)
+"bHU" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "bIa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6412,6 +6418,10 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/hallway/floor4/fore)
+"bJW" = (
+/obj/structure/ladder,
+/turf/open/floor/plating/foam,
+/area/maintenance/floor1/port/aft)
 "bKc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -7090,6 +7100,10 @@
 	dir = 8
 	},
 /area/security/brig)
+"bUe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "bUh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -9653,6 +9667,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/faction/unity)
+"cKs" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "cKt" = (
 /obj/structure/sign/deck3{
 	pixel_y = 30
@@ -9775,6 +9795,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
+"cMh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "cMi" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -10253,6 +10278,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
+"cUN" = (
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 10
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "cUY" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -10295,10 +10327,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"cVw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "cVG" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -10702,6 +10730,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater/abandoned)
+"dcN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "dcO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -11271,13 +11305,6 @@
 	dir = 4
 	},
 /area/command/heads_quarters/hos)
-"dlP" = (
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 4
-	},
-/obj/effect/spawner/random/engineering/atmospherics_portable,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "dlR" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -11322,6 +11349,19 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
+"dmR" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor4/port)
 "dmU" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen,
@@ -11738,13 +11778,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/lockers)
-"dtV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor1/port)
 "dtX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -14791,11 +14824,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/cargo/scrapbeacon)
-"eph" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "epj" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -14934,14 +14962,6 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/service/bar)
-"esb" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/ladder,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/openspace,
-/area/maintenance/floor2/port)
 "ess" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/effect/turf_decal/trimline/white/line{
@@ -15592,17 +15612,6 @@
 "eEQ" = (
 /turf/open/floor/iron/checker,
 /area/commons/locker)
-"eER" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing/corner,
-/obj/machinery/button/elevator{
-	id = "portmaint_lift";
-	pixel_y = -26
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/port)
 "eET" = (
 /obj/structure/filingcabinet/medical,
 /turf/open/floor/iron/dark/corner,
@@ -16729,13 +16738,6 @@
 "faF" = (
 /turf/open/floor/iron/smooth,
 /area/construction)
-"faI" = (
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 6
-	},
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "faJ" = (
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -17142,10 +17144,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass/fairy,
 /area/maintenance/club)
-"fjd" = (
-/obj/structure/foamedmetal,
-/turf/open/openspace,
-/area/maintenance/floor2/port)
 "fjk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17768,11 +17766,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"fum" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/purple/warning,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "fur" = (
 /obj/machinery/destructive_scanner,
 /turf/open/floor/iron/dark,
@@ -17784,13 +17777,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/aft)
-"fuE" = (
-/obj/structure/railing,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor1/port)
 "fuJ" = (
 /obj/machinery/door/airlock/mining/glass,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
@@ -18175,10 +18161,6 @@
 	dir = 6
 	},
 /area/hallway/floor1/aft)
-"fBh" = (
-/obj/structure/ladder,
-/turf/open/floor/plating/foam,
-/area/maintenance/floor1/port/aft)
 "fBk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -18504,6 +18486,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
+"fGI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "fGJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/pod/light,
@@ -19131,6 +19120,10 @@
 /obj/structure/cable,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/port/fore)
+"fRp" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "fRx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/tank_holder,
@@ -19336,6 +19329,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output,
 /turf/open/floor/engine/airless,
 /area/engineering/atmos)
+"fUT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "fVe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -19654,6 +19654,16 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/green,
 /area/faction/conserve_recycling)
+"gaH" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/maintenance/floor1/port)
 "gaU" = (
 /obj/structure/closet/firecloset/full,
 /obj/machinery/light/small/directional/south,
@@ -20152,10 +20162,6 @@
 	dir = 5
 	},
 /area/hallway/floor4/fore)
-"giI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "giM" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/kitchen,
@@ -20166,6 +20172,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/pod,
 /area/faction/survey_wings)
+"giV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port/aft)
 "giX" = (
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/port/aft)
@@ -21446,6 +21457,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
+"gFz" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "gFE" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/machinery/newscaster/directional/east,
@@ -22365,13 +22384,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor1/aft)
-"gWG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/maintenance/floor2/port)
 "gWN" = (
 /obj/structure/railing{
 	dir = 1
@@ -23353,9 +23365,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor3/aft)
-"hlu" = (
-/turf/open/floor/plating/elevatorshaft,
-/area/maintenance/floor2/port)
 "hlB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23533,11 +23542,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
-"hnZ" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "hob" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24984,12 +24988,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/locker)
-"hLq" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/red/warning,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "hLs" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_half,
@@ -25059,18 +25057,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"hLR" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor4/port)
 "hLX" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Bulkhead"
@@ -27956,16 +27942,6 @@
 "iFD" = (
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"iFO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/button/elevator{
-	id = "portmaint_lift";
-	pixel_y = -26
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor3/port/aft)
 "iGh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28045,8 +28021,11 @@
 /turf/open/floor/wood/parquet,
 /area/medical/break_room)
 "iHc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/port)
 "iHf" = (
 /obj/structure/table,
@@ -28703,6 +28682,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"iRN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "iSc" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -29348,6 +29339,10 @@
 	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard/fore)
+"jer" = (
+/obj/structure/foamedmetal,
+/turf/open/openspace,
+/area/maintenance/floor2/port)
 "jeA" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29443,12 +29438,6 @@
 "jgd" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"jgh" = (
-/obj/effect/spawner/structure/window/hollow/end{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "jgm" = (
 /obj/structure/bed,
 /obj/item/bedsheet/cult,
@@ -29687,19 +29676,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/engineering/main)
-"jlz" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/port)
 "jlC" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/eighties/red,
@@ -31197,6 +31173,18 @@
 /obj/machinery/teleport/hub,
 /turf/open/floor/iron/dark,
 /area/faction/unity)
+"jHr" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "jHu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
@@ -31577,11 +31565,6 @@
 	icon_state = "damaged3"
 	},
 /area/maintenance/floor4/starboard)
-"jNG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "jNL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side{
@@ -32918,12 +32901,6 @@
 /obj/machinery/light/cold/no_nightlight/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"kiI" = (
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 5
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "kiM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -33308,6 +33285,19 @@
 /obj/structure/foamedmetal,
 /turf/open/floor/plating/foam,
 /area/maintenance/floor1/port/aft)
+"kpX" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "kqf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -33791,13 +33781,6 @@
 /obj/item/storage/toolbox/edict,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/last_edict)
-"kxn" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/openspace,
-/area/maintenance/floor2/port)
 "kxo" = (
 /turf/closed/wall/r_wall,
 /area/cargo/miningdock)
@@ -34175,6 +34158,9 @@
 	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
+"kEd" = (
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/hos)
 "kEe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34196,15 +34182,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"kEs" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Power Generation Experimentation"
-	},
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "kEu" = (
 /obj/structure/sign/poster/contraband/atmosia_independence{
 	pixel_x = -32
@@ -34654,13 +34631,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
-"kKy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/maintenance/floor2/port)
 "kKE" = (
 /obj/structure/railing{
 	dir = 8
@@ -35776,12 +35746,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
 "lcv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/maintenance/floor2/port)
 "lcF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -37463,6 +37428,13 @@
 /obj/item/experi_scanner,
 /turf/open/floor/iron/white,
 /area/science/research)
+"lCF" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 6
+	},
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "lCI" = (
 /obj/structure/window/reinforced/fulltile/ec_glass{
 	id = "orprivacy_a"
@@ -37957,6 +37929,12 @@
 	dir = 1
 	},
 /area/commons/cryo_storage)
+"lKp" = (
+/obj/machinery/atmospherics/components/trinary/mixer,
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "lKq" = (
 /obj/structure/reflector/single/anchored{
 	dir = 6
@@ -38300,12 +38278,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/hallway/floor3/aft)
-"lPA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "lPL" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
@@ -38613,6 +38585,19 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/red/side,
 /area/security/brig)
+"lTN" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "lTV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/mineral/ore_redemption,
@@ -39039,6 +39024,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/floor1/port)
+"maQ" = (
+/obj/machinery/airalarm/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "maR" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -39460,6 +39450,12 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor4/starboard)
+"mgc" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 5
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "mgg" = (
 /turf/closed/wall,
 /area/engineering/atmos/hfr_room)
@@ -39887,11 +39883,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
-"mnp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/port)
 "mnq" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40538,16 +40529,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
 /area/maintenance/floor2/port/aft)
-"mvT" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/pod/light,
-/area/maintenance/floor1/port)
 "mwc" = (
 /obj/structure/chair{
 	dir = 8
@@ -41043,10 +41024,12 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "mEa" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
+/obj/structure/railing,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/port)
 "mEg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
@@ -42207,6 +42190,14 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/service/lawoffice)
+"mWr" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/ladder,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/maintenance/floor2/port)
 "mWD" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
@@ -43368,6 +43359,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/white,
 /area/medical/abandoned)
+"nne" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/pod/light,
+/area/maintenance/floor3/port/aft)
 "nnj" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_loot_count = 3;
@@ -43996,6 +43992,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_large,
 /area/cargo/miningoffice)
+"nvT" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "nvU" = (
 /turf/open/floor/plating/airless,
 /area/solars/port/fore)
@@ -44052,19 +44056,6 @@
 "nwW" = (
 /turf/open/floor/engine,
 /area/science/cytology)
-"nwX" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Bulkhead"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "nxs" = (
 /obj/structure/railing,
 /turf/open/floor/iron/dark,
@@ -45883,6 +45874,12 @@
 /obj/machinery/light/small/blacklight/directional/west,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/port/aft)
+"nYX" = (
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 10
+	},
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/port)
 "nYZ" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47465,6 +47462,19 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor3/fore)
+"oxJ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/port)
 "oxO" = (
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/plating,
@@ -47538,6 +47548,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
+"oyJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/port)
 "oyN" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 10
@@ -48582,12 +48599,6 @@
 /obj/item/folder/yellow,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard/fore)
-"oPS" = (
-/obj/effect/turf_decal/trimline/purple/warning{
-	dir = 10
-	},
-/turf/open/floor/pod/light,
-/area/maintenance/floor2/port)
 "oPX" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -49002,7 +49013,9 @@
 	},
 /area/hallway/floor1/fore)
 "oVH" = (
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/maintenance/floor2/port)
 "oVO" = (
 /obj/structure/sign/warning/vacuum,
@@ -50636,6 +50649,13 @@
 /obj/effect/turf_decal/tile/red/half,
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor4/fore)
+"pzx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/port)
 "pzE" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plating,
@@ -51217,6 +51237,14 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/aft)
+"pJv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "pJz" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/morphine{
@@ -51588,6 +51616,12 @@
 	dir = 4
 	},
 /area/ai_monitored/turret_protected/aisat_interior)
+"pQo" = (
+/obj/structure/industrial_lift{
+	id = "portmaint_lift"
+	},
+/turf/open/openspace,
+/area/maintenance/floor3/port/aft)
 "pQH" = (
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
@@ -51917,13 +51951,6 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating/airless,
 /area/solars/starboard/aft)
-"pXu" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/purple/warning{
-	dir = 10
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "pXL" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/corner,
@@ -51991,14 +52018,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
-"pYi" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "pYl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/blue,
@@ -53204,6 +53223,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/maintenance/floor2/port/aft)
+"qtm" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/purple/warning{
+	dir = 10
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "qtz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/garbage{
@@ -53966,13 +53992,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
-"qDU" = (
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 10
-	},
-/obj/effect/spawner/random/structure/tank_holder,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "qEh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53990,12 +54009,6 @@
 	dir = 10
 	},
 /area/security/courtroom)
-"qEA" = (
-/obj/machinery/atmospherics/components/trinary/mixer,
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "qEB" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -54538,6 +54551,11 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"qMV" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "qMW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/green/side,
@@ -55105,14 +55123,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"qVi" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4
-	},
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "qVk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -56836,6 +56846,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/command/bridge)
+"rzA" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "rzI" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/chair/stool/bar/directional/east,
@@ -56847,13 +56865,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"rzQ" = (
-/obj/effect/turf_decal/trimline/blue/warning{
-	dir = 4
-	},
-/obj/effect/spawner/random/engineering/canister,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "rzW" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -57026,6 +57037,11 @@
 	},
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
+"rCz" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "rCH" = (
 /obj/structure/frame/machine,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -58035,6 +58051,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port/fore)
+"rTL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing/corner,
+/obj/machinery/button/elevator{
+	id = "portmaint_lift";
+	pixel_y = -26
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "rTV" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table/wood,
@@ -58166,19 +58193,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side,
 /area/security/office)
-"rWb" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor3/port)
 "rWo" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/pod/light,
@@ -59468,18 +59482,6 @@
 "suX" = (
 /turf/closed/wall/r_wall,
 /area/faction/homeguard)
-"svi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/port)
 "svm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -59848,6 +59850,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/abandoned)
+"sAA" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Power Generation Experimentation"
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "sAF" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -60798,13 +60809,6 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
-"sPY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/port)
 "sQa" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -60926,11 +60930,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
-"sSi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "sSl" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -61574,14 +61573,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"sZP" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "sZT" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor/border_only{
@@ -61601,6 +61592,13 @@
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"sZY" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "sZZ" = (
 /obj/item/stack/cable_coil/five{
 	amount = 1
@@ -61887,6 +61885,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"tez" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "teB" = (
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -61951,6 +61957,11 @@
 /obj/structure/girder,
 /turf/open/floor/engine/hull/reinforced,
 /area/space)
+"tfR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/port)
 "tfS" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/turf_decal/trimline/green/line{
@@ -62044,6 +62055,16 @@
 "til" = (
 /obj/structure/sign/poster/contraband/grey_tide,
 /turf/closed/wall,
+/area/maintenance/floor3/port/aft)
+"tiv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/button/elevator{
+	id = "portmaint_lift";
+	pixel_y = -26
+	},
+/turf/open/floor/catwalk_floor,
 /area/maintenance/floor3/port/aft)
 "tiC" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -62213,7 +62234,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor4/port)
 "tkU" = (
@@ -63174,11 +63194,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark/red/side,
 /area/security/prison)
-"tBl" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/pod/light,
-/area/maintenance/floor3/port/aft)
 "tBp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -63186,11 +63201,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/engineering/break_room)
-"tBu" = (
-/obj/structure/grille,
-/obj/structure/closet/emcloset,
-/turf/open/floor/pod/light,
-/area/maintenance/floor2/port/fore)
 "tBv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -64965,11 +64975,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/lower)
-"ufx" = (
-/obj/machinery/airalarm/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "ufA" = (
 /obj/structure/table/rolling,
 /obj/item/storage/backpack/duffelbag/med/surgery{
@@ -65053,14 +65058,6 @@
 	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
-"ugc" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "ugr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/firealarm/directional/west,
@@ -65076,6 +65073,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/project)
+"uhg" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor1/port)
 "uhk" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/blue,
@@ -65246,19 +65254,6 @@
 /obj/structure/stairs/east,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
-"ujm" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Bulkhead"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "ujo" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -65963,15 +65958,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/theater)
-"uxn" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor1/port)
 "uxt" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -65996,6 +65982,13 @@
 	},
 /turf/open/floor/wood,
 /area/service/dining)
+"uxP" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 10
+	},
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "uxW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/mess,
@@ -66172,10 +66165,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "uAe" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port/aft)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "uAk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -69169,13 +69161,6 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plating/airless,
 /area/solars/port/fore)
-"vvU" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "vvW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -69818,6 +69803,13 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/grass,
 /area/science/xenobiology)
+"vHt" = (
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 4
+	},
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "vHw" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
@@ -70489,6 +70481,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/pod,
 /area/maintenance/floor4/port/fore)
+"vSQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "vSS" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -71412,13 +71411,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/maintenance/floor3/port/fore)
-"wiE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/floor2/port)
 "wiH" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
@@ -73451,6 +73443,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured_half,
 /area/hallway/secondary/exit/departure_lounge)
+"wLX" = (
+/obj/effect/spawner/structure/window/hollow/end{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "wMr" = (
 /obj/machinery/door/airlock{
 	id_tag = "dorms_c_bolts";
@@ -73546,6 +73544,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"wNN" = (
+/turf/open/floor/plating/elevatorshaft,
+/area/maintenance/floor2/port)
 "wNR" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/rack,
@@ -73732,13 +73733,6 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor3/fore)
-"wRu" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4
-	},
-/obj/effect/spawner/random/engineering/tank,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "wRx" = (
 /obj/machinery/vending/wallmed/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -74232,6 +74226,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/starboard/fore)
+"wYM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/maintenance/floor2/port)
 "wYP" = (
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
@@ -74764,6 +74765,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"xhf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/floor2/port)
 "xhk" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/cable,
@@ -76041,13 +76046,6 @@
 	dir = 4
 	},
 /area/hallway/floor2/fore)
-"xAj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/port)
 "xAl" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -76486,13 +76484,6 @@
 "xGl" = (
 /turf/open/floor/plating/foam,
 /area/maintenance/floor1/port/aft)
-"xGs" = (
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/trimline/purple/warning{
-	dir = 10
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/port)
 "xGx" = (
 /obj/structure/window/reinforced/fulltile/ec_glass{
 	id = "law_ec"
@@ -76694,6 +76685,13 @@
 	dir = 1
 	},
 /area/maintenance/floor3/starboard/aft)
+"xJT" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 4
+	},
+/obj/effect/spawner/random/engineering/canister,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "xKa" = (
 /obj/effect/turf_decal/stripes/white/corner,
 /turf/open/floor/iron/dark/corner,
@@ -77860,6 +77858,11 @@
 /obj/item/cigbutt,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
+"ydS" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/port)
 "yef" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes,
@@ -110597,7 +110600,7 @@ cFr
 kzE
 twx
 twx
-fuE
+mEa
 xfT
 rYa
 xfT
@@ -110854,7 +110857,7 @@ cFr
 kzE
 bMz
 eOY
-fuE
+mEa
 xfT
 xrB
 xfT
@@ -111111,7 +111114,7 @@ kET
 kzE
 twx
 oTc
-fuE
+mEa
 xfT
 xfT
 xfT
@@ -111368,10 +111371,10 @@ cFr
 kzE
 gbh
 twx
-uxn
-alH
-alH
-alH
+asf
+uhg
+uhg
+uhg
 sat
 xgH
 xgH
@@ -116509,8 +116512,8 @@ hdA
 uLj
 bQV
 bQV
-mvT
-mvT
+gaH
+gaH
 rfz
 xgH
 xgH
@@ -118050,7 +118053,7 @@ xgH
 hdA
 hdA
 hdA
-dtV
+oyJ
 hdA
 hdA
 bpE
@@ -122162,7 +122165,7 @@ dEc
 nJt
 nJt
 nJt
-fBh
+bJW
 mrs
 riT
 cll
@@ -170730,7 +170733,7 @@ hLz
 hLz
 hLz
 hLz
-tBu
+awN
 uXA
 hLz
 hZP
@@ -173052,7 +173055,7 @@ ajq
 aal
 aal
 aal
-nwX
+kpX
 aal
 aal
 aal
@@ -173308,8 +173311,8 @@ eOv
 rQX
 aal
 hCh
-cVw
-gWG
+uAe
+adq
 xQG
 aal
 aal
@@ -173565,9 +173568,9 @@ eOv
 bbg
 aal
 aal
-mEa
-gWG
-ufx
+ydS
+adq
+maQ
 aal
 aal
 ucA
@@ -173821,10 +173824,10 @@ xQo
 eOv
 bbg
 aal
-hLq
-jNG
-kKy
-cVw
+cKs
+cMh
+pzx
+uAe
 aal
 aal
 ucA
@@ -174080,7 +174083,7 @@ tQu
 aal
 aal
 aal
-ujm
+lTN
 aal
 aal
 aal
@@ -176137,7 +176140,7 @@ aal
 hAg
 kFd
 hAg
-biS
+jHr
 aal
 aal
 ucA
@@ -176394,7 +176397,7 @@ aal
 hAg
 lrA
 hAg
-jlz
+biS
 aal
 aal
 ucA
@@ -176651,7 +176654,7 @@ aal
 hAg
 hAg
 hAg
-biS
+jHr
 aal
 aal
 ucA
@@ -181532,7 +181535,7 @@ feM
 feM
 vwv
 aal
-xAj
+fUT
 nPo
 aal
 aal
@@ -181789,7 +181792,7 @@ aal
 aal
 aal
 aal
-sPY
+fGI
 aal
 aal
 aal
@@ -182048,8 +182051,8 @@ ybG
 ybG
 ybG
 ybG
-iHc
-iHc
+xhf
+xhf
 ucA
 ucA
 ucA
@@ -183333,8 +183336,8 @@ ybG
 ybG
 ybG
 ybG
-iHc
-iHc
+xhf
+xhf
 ucA
 ucA
 ucA
@@ -183830,7 +183833,7 @@ wFq
 hoj
 lsQ
 aal
-rzQ
+xJT
 aal
 aal
 uNB
@@ -183841,12 +183844,12 @@ aal
 aal
 aal
 aal
-sSi
+oVH
 aal
 ybG
 mbi
-hlu
-hlu
+wNN
+wNN
 aal
 aal
 ucA
@@ -184089,21 +184092,21 @@ cqh
 vff
 ybG
 ybG
-bAO
+fRp
 ybG
 ybG
 ybG
-kiI
-dlP
-wRu
+mgc
+iHc
+vHt
 aal
-sSi
-sSi
+oVH
+oVH
 aal
-qDU
+uxP
 mbi
-hlu
-hlu
+wNN
+wNN
 aal
 aal
 ucA
@@ -184344,21 +184347,21 @@ wGg
 jZS
 sFQ
 aal
-oPS
+nYX
 ybG
 ybG
 ybG
-jgh
+wLX
 ybG
 ybG
 ybG
-kiI
+mgc
 aal
 aal
 aal
 aal
-faI
-eER
+lCF
+rTL
 aal
 aal
 aal
@@ -184607,7 +184610,7 @@ aal
 aal
 aal
 aal
-pXu
+qtm
 ybG
 ybG
 ybG
@@ -184864,14 +184867,14 @@ bif
 fSi
 bnI
 aal
-fum
+aAK
 ybG
 aal
 aal
 aal
 aal
 trY
-xGs
+cUN
 pnc
 lfy
 lfy
@@ -186668,12 +186671,12 @@ bsK
 bxr
 bzY
 aal
-sSi
-sSi
+oVH
+oVH
 aal
 pHQ
-svi
-svi
+iRN
+iRN
 aal
 aal
 ucA
@@ -186924,13 +186927,13 @@ kqL
 btW
 bxZ
 bAc
-oVH
-oVH
-oVH
-oVH
-hnZ
-oVH
-xAj
+lcv
+lcv
+lcv
+lcv
+rCz
+lcv
+fUT
 aal
 aal
 ucA
@@ -187180,16 +187183,16 @@ brC
 ltt
 jXc
 byj
-oVH
-oVH
+lcv
+lcv
 hAg
 hAg
-kxn
-wiE
-hnZ
+wYM
+vSQ
+rCz
 ybG
-iHc
-iHc
+xhf
+xhf
 ucA
 ucA
 ucA
@@ -187437,14 +187440,14 @@ oZj
 jkH
 jXc
 aVg
-oVH
-fjd
+lcv
+jer
 hAg
 hAg
-kxn
-wiE
-hnZ
-mnp
+wYM
+vSQ
+rCz
+tfR
 aal
 aal
 ucA
@@ -187694,13 +187697,13 @@ iaC
 oZc
 jXc
 tch
-oVH
-fjd
-fjd
+lcv
+jer
+jer
 hAg
-esb
-lPA
-hnZ
+mWr
+dcN
+rCz
 ybG
 aal
 aal
@@ -187951,13 +187954,13 @@ bfs
 cVT
 jXc
 byx
-oVH
-oVH
-aAO
-aAO
-oVH
-kEs
-oVH
+lcv
+lcv
+bHU
+bHU
+lcv
+sAA
+lcv
 ybG
 aal
 aal
@@ -188209,12 +188212,12 @@ kqL
 btW
 byH
 bAj
-oVH
-sZP
-giI
+lcv
+pJv
+bUe
 lfy
-vvU
-oVH
+sZY
+lcv
 ybG
 aal
 aal
@@ -188466,12 +188469,12 @@ btt
 opr
 byI
 bAn
-oVH
-qVi
-ugc
 lcv
-giI
-oVH
+rzA
+gFz
+tez
+bUe
+lcv
 ybG
 aal
 aal
@@ -188713,7 +188716,7 @@ xui
 dEJ
 xui
 slk
-uAe
+giV
 nlN
 nlN
 nlN
@@ -188723,12 +188726,12 @@ nlN
 nlN
 nlN
 nlN
-oVH
-pYi
-eph
-qEA
-ugc
-oVH
+lcv
+nvT
+qMV
+lKp
+gFz
+lcv
 ybG
 aal
 aal
@@ -188970,8 +188973,8 @@ tPm
 tPm
 xui
 nlN
-uAe
-uAe
+giV
+giV
 nlN
 pEp
 pEp
@@ -188980,15 +188983,15 @@ pEp
 gwT
 pPG
 nlN
-oVH
-oVH
-oVH
-oVH
-oVH
-oVH
+lcv
+lcv
+lcv
+lcv
+lcv
+lcv
 ybG
-iHc
-iHc
+xhf
+xhf
 ucA
 ucA
 ucA
@@ -242442,7 +242445,7 @@ tGn
 ajs
 vKw
 wNH
-rWb
+oxJ
 wNH
 geL
 tGn
@@ -249380,9 +249383,9 @@ pOn
 pOn
 pOn
 pOn
-tBl
-bHz
-bHz
+nne
+pQo
+pQo
 piR
 piR
 ucA
@@ -249637,9 +249640,9 @@ piR
 piR
 piR
 pOn
-tBl
-bHz
-bHz
+nne
+pQo
+pQo
 piR
 piR
 ucA
@@ -249893,7 +249896,7 @@ piR
 pOn
 pOn
 pOn
-iFO
+tiv
 piR
 piR
 piR
@@ -301031,7 +301034,7 @@ qLp
 xqY
 qLp
 qLp
-qLp
+kEd
 piE
 gDN
 pke
@@ -306949,9 +306952,9 @@ cSq
 fSD
 sPs
 vEa
+dmR
 tkM
-hLR
-hLR
+tkM
 pze
 fXs
 fXs

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -359,6 +359,10 @@
 /obj/structure/ladder,
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/starboard)
+"aeb" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "aeg" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/wood{
@@ -1567,7 +1571,7 @@
 "awA" = (
 /obj/structure/table/reinforced,
 /obj/item/screwdriver,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "awH" = (
 /obj/effect/decal/cleanable/glass,
@@ -1600,6 +1604,13 @@
 	dir = 9
 	},
 /area/hallway/floor1/fore)
+"axf" = (
+/obj/item/bodypart/l_arm/robot,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "axn" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 8
@@ -1895,6 +1906,10 @@
 	},
 /turf/open/floor/engine/beacon,
 /area/cargo/scrapbeacon)
+"aBx" = (
+/obj/structure/rack/shelf,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "aBC" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
@@ -2084,13 +2099,6 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor1/fore)
-"aEl" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "aEm" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -2927,13 +2935,6 @@
 	dir = 1
 	},
 /area/commons/cryo_storage)
-"aPP" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "aQk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 2
@@ -3230,7 +3231,10 @@
 "aUe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "aUj" = (
 /obj/effect/turf_decal/siding/wideplating_new/end{
@@ -3609,6 +3613,10 @@
 "aZw" = (
 /turf/open/floor/pod/dark,
 /area/maintenance/floor3/port/fore)
+"aZA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "aZC" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
@@ -3621,6 +3629,15 @@
 "aZG" = (
 /turf/closed/wall,
 /area/service/chapel)
+"aZI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/starboard/aft)
 "aZM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -4935,17 +4952,6 @@
 	dir = 8
 	},
 /area/science/robotics/lab)
-"bqi" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/warning,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/light,
-/area/maintenance/floor2/starboard)
 "bqu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
@@ -5475,6 +5481,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/service/library/upper)
+"bwK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "bwL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5848,6 +5859,10 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
 /area/cargo/miningdock)
+"bAP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/starboard)
 "bAQ" = (
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 1
@@ -6066,6 +6081,14 @@
 "bEK" = (
 /obj/structure/holosign/barrier,
 /turf/open/floor/iron/dark/red,
+/area/maintenance/floor2/starboard/aft)
+"bET" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "bEV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6865,6 +6888,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
+"bRI" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "bRJ" = (
 /turf/open/floor/iron/dark/red/side{
 	dir = 5
@@ -7211,11 +7240,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
-"bXx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/library/garden)
+"bXh" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "bXC" = (
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 8
@@ -7679,10 +7711,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/pumproom)
-"cfp" = (
-/obj/effect/spawner/random/structure/barricade,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "cfu" = (
 /obj/structure/railing{
 	dir = 1
@@ -9302,7 +9330,7 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/starboard/fore)
 "cGu" = (
-/turf/open/floor/pod/dark,
+/turf/open/floor/glass/reinforced,
 /area/maintenance/floor2/starboard/aft)
 "cGA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -9770,11 +9798,6 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/service/chapel/funeral)
-"cNJ" = (
-/obj/structure/ladder,
-/obj/structure/window,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "cNP" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /obj/machinery/camera/motion/directional/south,
@@ -9798,6 +9821,10 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark,
 /area/hallway/floor3/fore)
+"cOD" = (
+/obj/machinery/atmospherics/components/binary/pump/layer2,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "cOG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -10191,13 +10218,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/cytology)
-"cUS" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 9
-	},
-/obj/effect/spawner/random/structure/closet_maintenance,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "cUY" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -10597,16 +10617,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"dai" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Bulkhead"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "daF" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
@@ -10816,6 +10826,13 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"dge" = (
+/obj/effect/turf_decal/stripes{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "dgf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/red/side{
@@ -11390,17 +11407,6 @@
 	dir = 4
 	},
 /area/service/lawoffice)
-"dpW" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/north,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "dqm" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/reagent_containers/blood/random,
@@ -12535,7 +12541,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/toggle/labcoat,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "dGp" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13556,9 +13562,6 @@
 /obj/item/hand_tele,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
-"dWA" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/maintenance/floor2/starboard)
 "dWJ" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -14253,10 +14256,11 @@
 /turf/open/floor/wood/tile,
 /area/command/heads_quarters/captain/private)
 "ehA" = (
-/obj/structure/shuttle/engine/propulsion/in_wall{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "ehD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14323,18 +14327,17 @@
 "ejd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/shuttle/engine/heater,
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "ejr" = (
-/obj/effect/turf_decal/trimline/green/warning{
+/obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
+/area/maintenance/floor2/starboard/aft)
 "ejA" = (
 /obj/structure/cable,
 /obj/machinery/computer/cargo/request,
@@ -14354,6 +14357,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/floor3/starboard/aft)
+"ejI" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "ejK" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -15406,16 +15419,6 @@
 "eDe" = (
 /turf/closed/wall,
 /area/hallway/floor3/fore)
-"eDt" = (
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "eDu" = (
 /obj/effect/turf_decal/stripes{
 	dir = 10
@@ -15644,10 +15647,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eHk" = (
-/obj/structure/shuttle/engine/propulsion/in_wall{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
 /turf/open/floor/iron{
 	icon_state = "floorscorched1"
 	},
@@ -17115,12 +17118,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
-"fke" = (
-/obj/effect/spawner/structure/window/hollow/directional{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/floor2/starboard)
 "fkf" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
@@ -17161,6 +17158,13 @@
 "fkA" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/floor4/port/aft)
+"fkD" = (
+/obj/effect/spawner/random/structure/tank_holder,
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 5
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "fkG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/white/line{
@@ -17346,12 +17350,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/floor3/fore)
-"fnp" = (
-/obj/effect/turf_decal/trimline/green/warning,
-/obj/effect/spawner/random/structure/tank_holder,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "fnA" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/turf_decal/siding/blue/corner,
@@ -17467,6 +17465,13 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/iron/dark/smooth_large,
 /area/service/library/printer)
+"fpt" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/corner{
+	dir = 1
+	},
+/area/maintenance/floor2/starboard/aft)
 "fpv" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/decal/cleanable/dirt,
@@ -17504,15 +17509,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/maintenance/floor4/port/aft)
-"fqd" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "fqg" = (
 /obj/structure/railing{
 	dir = 8
@@ -17541,11 +17537,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/cryo_storage)
-"fqM" = (
-/obj/item/stack/cable_coil/cut,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "frz" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/structure/rack,
@@ -18161,6 +18152,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/floor1/starboard/fore)
+"fCx" = (
+/obj/structure/rack/shelf,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "fCz" = (
 /obj/structure/rack,
 /obj/item/storage/box/firingpins{
@@ -18524,6 +18519,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"fIM" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/starboard/aft)
 "fIX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
@@ -18852,6 +18852,11 @@
 /obj/structure/cable,
 /turf/open/floor/eighties,
 /area/commons/fitness/recreation/entertainment)
+"fOK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "fOS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
@@ -19341,9 +19346,7 @@
 /turf/open/floor/carpet/blue,
 /area/command/meeting_room)
 "fXq" = (
-/obj/effect/decal/cleanable/robot_debris/up,
-/obj/item/assembly/prox_sensor,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/maintenance/floor2/starboard/aft)
 "fXr" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -20459,6 +20462,16 @@
 /obj/item/reagent_containers/food/drinks/bottle/patron,
 /turf/open/floor/wood,
 /area/maintenance/floor3/starboard/aft)
+"gqJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth_large,
+/area/maintenance/floor2/starboard/aft)
 "gqN" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -20490,6 +20503,11 @@
 "grg" = (
 /turf/open/floor/iron,
 /area/hallway/floor1/fore)
+"gri" = (
+/obj/effect/turf_decal/stripes,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "grk" = (
 /obj/effect/landmark/start/roboticist,
 /turf/open/floor/iron,
@@ -20821,10 +20839,6 @@
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/iron/dark,
 /area/maintenance/floor2/starboard/aft)
-"gxj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "gxn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21263,6 +21277,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/fore)
+"gEL" = (
+/obj/effect/spawner/structure/window/hollow/directional{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "gEW" = (
 /obj/machinery/computer/communications{
 	dir = 1
@@ -21310,6 +21330,11 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/command/heads_quarters/cmo)
+"gFO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "gFQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21318,6 +21343,11 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/aft)
+"gFS" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "gFU" = (
 /obj/machinery/computer/exodrone_control_console,
 /turf/open/floor/iron/dark,
@@ -21489,9 +21519,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/engineering/gravity_generator)
 "gKo" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron/dark/red,
 /area/security/checkpoint/second)
 "gKp" = (
@@ -21731,10 +21758,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"gOb" = (
-/obj/effect/spawner/structure/window/hollow/end,
-/turf/open/floor/plating,
-/area/maintenance/floor2/starboard)
 "gOd" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname/directional/west,
@@ -21756,6 +21779,10 @@
 	dir = 8
 	},
 /area/medical/chemistry)
+"gOp" = (
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "gOs" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/machinery/holopad,
@@ -22024,6 +22051,10 @@
 	dir = 9
 	},
 /area/faction/homeguard)
+"gTs" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "gTt" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/dark/textured,
@@ -22059,6 +22090,10 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/engine/cult,
 /area/service/library/private)
+"gUf" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "gUg" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/light_switch/directional/west,
@@ -22902,6 +22937,16 @@
 	},
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
+"hgQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth_large,
+/area/maintenance/floor2/starboard/aft)
 "hhk" = (
 /obj/structure/foamedmetal,
 /turf/open/floor/plating,
@@ -23056,6 +23101,14 @@
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
+"hjP" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/blue/side{
+	dir = 4
+	},
+/area/maintenance/floor2/starboard/aft)
 "hjV" = (
 /obj/item/stack/sheet/iron,
 /turf/open/floor/iron/dark,
@@ -23613,6 +23666,13 @@
 /obj/item/stack/arcadeticket,
 /turf/open/floor/eighties,
 /area/commons/fitness/recreation/entertainment)
+"hsW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "htc" = (
 /obj/effect/turf_decal/trimline/green/arrow_cw{
 	dir = 1
@@ -23642,17 +23702,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/service)
-"hty" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Bulkhead"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "htG" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Bulkhead"
@@ -25233,6 +25282,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/general,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/hallway/secondary/service)
+"hSI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard/aft)
 "hSJ" = (
 /obj/structure/rack,
 /obj/item/storage/medkit/regular,
@@ -26237,10 +26293,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/cmo)
-"ihb" = (
-/obj/effect/spawner/structure/window/hollow/middle,
-/turf/open/floor/plating,
-/area/maintenance/floor2/starboard)
 "ihd" = (
 /obj/machinery/computer/atmos_control/mix_tank,
 /obj/structure/window/reinforced/spawner/north,
@@ -26624,6 +26676,12 @@
 	dir = 8
 	},
 /area/security/prison)
+"imI" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "imJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26791,6 +26849,14 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"ioZ" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/maintenance/floor2/starboard/aft)
 "ipa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/graffiti{
@@ -26804,6 +26870,11 @@
 "ipn" = (
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/hop)
+"ipu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "ipA" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -26956,6 +27027,13 @@
 	dir = 4
 	},
 /area/security/brig)
+"isk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing/corner,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard/aft)
 "isl" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Shelter"
@@ -27097,6 +27175,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/floor1/port)
+"ius" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "iuA" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27579,6 +27661,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor4/starboard/aft)
+"iDh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "iDk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28856,6 +28942,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"jas" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "jat" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -29371,6 +29462,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
+"jko" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/library/garden)
 "jks" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30571,7 +30667,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
 /obj/item/bot_assembly/floorbot,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "jBm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30795,7 +30891,8 @@
 "jFB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron,
 /area/maintenance/floor2/starboard/aft)
 "jFH" = (
 /obj/machinery/requests_console/directional/north{
@@ -31291,6 +31388,10 @@
 	dir = 1
 	},
 /area/commons/cryo_storage)
+"jNP" = (
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "jNR" = (
 /obj/structure/table,
 /obj/item/stock_parts/manipulator{
@@ -31366,6 +31467,7 @@
 	name = "Starboard Quarter Solars"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/structure/railing/corner,
 /turf/open/floor/pod/light,
 /area/maintenance/solars/starboard/aft)
 "jOX" = (
@@ -31376,6 +31478,10 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/starboard/aft)
+"jPg" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "jPj" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31556,6 +31662,12 @@
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/faction/homeguard)
+"jRW" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/floor2/starboard/aft)
 "jRX" = (
 /obj/structure/sign/departments/engineering,
 /turf/closed/wall,
@@ -31640,6 +31752,11 @@
 	dir = 1
 	},
 /area/cargo/miningdock)
+"jUJ" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "jUL" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
@@ -32481,9 +32598,9 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "kgY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "kgZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/pod/dark,
@@ -32691,8 +32808,11 @@
 /turf/open/floor/carpet/orange,
 /area/service/chapel/funeral)
 "kkI" = (
-/obj/structure/ladder,
-/turf/open/floor/pod/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/starboard/aft)
 "kkK" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -32948,14 +33068,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/cargo/scrapbeacon)
-"kpw" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/structure/table_or_rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "kpx" = (
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -33919,6 +34031,17 @@
 	dir = 4
 	},
 /area/hallway/floor2/aft)
+"kEY" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "kFb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -33943,6 +34066,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"kFp" = (
+/obj/effect/turf_decal/trimline/blue/warning{
+	dir = 10
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "kFv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -34242,6 +34371,10 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/department/medical/central)
+"kJU" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "kKa" = (
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/white,
@@ -34487,6 +34620,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/pod,
 /area/maintenance/floor4/port/fore)
+"kMk" = (
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "kMl" = (
 /obj/machinery/shower{
 	dir = 4
@@ -35198,6 +35339,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
+"kYv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor3/starboard/aft)
 "kYD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/smooth_large,
@@ -35673,6 +35823,11 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/starboard)
+"lgO" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/trimline/blue/warning,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "lgX" = (
 /obj/machinery/door/airlock/command{
 	name = "Unity Boardroom"
@@ -35818,10 +35973,6 @@
 /obj/item/reagent_containers/glass/bowl/mushroom_bowl,
 /turf/open/floor/noslip,
 /area/maintenance/floor1/port)
-"ljp" = (
-/obj/structure/rack/shelf,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "ljs" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/camera/directional/east{
@@ -36221,11 +36372,16 @@
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
 "loM" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch"
-	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/turf/open/floor/pod/light,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospheric Substation"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "loN" = (
 /turf/open/floor/iron,
@@ -36864,6 +37020,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
+"lyR" = (
+/obj/structure/window/reinforced,
+/obj/structure/table,
+/turf/open/floor/iron/dark/red/side{
+	dir = 8
+	},
+/area/security/checkpoint/second)
 "lyS" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/grass{
@@ -38374,6 +38537,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"lXn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "lXq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38456,6 +38624,19 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor1/fore)
+"lYb" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "lYd" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
@@ -38747,6 +38928,12 @@
 	dir = 4
 	},
 /area/engineering/atmos)
+"mcp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/maintenance/floor2/starboard/aft)
 "mcq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -38934,6 +39121,9 @@
 /obj/item/wrench{
 	pixel_x = -10;
 	pixel_y = 7
+	},
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/maintenance/floor2/starboard/aft)
@@ -39277,6 +39467,9 @@
 	pixel_y = 9
 	},
 /obj/item/stack/cable_coil,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/maintenance/floor2/starboard/aft)
 "mly" = (
@@ -42885,6 +43078,13 @@
 	},
 /turf/open/floor/wood/tile,
 /area/service/library/lounge)
+"nmK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/shard,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "nmL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
@@ -43894,6 +44094,14 @@
 	dir = 10
 	},
 /area/security/courtroom)
+"nBO" = (
+/obj/machinery/door/airlock/command{
+	name = "Rusted Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue,
+/area/maintenance/floor2/starboard/aft)
 "nBT" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44070,6 +44278,11 @@
 "nFa" = (
 /turf/open/floor/iron/dark/red/side,
 /area/security/execution/education)
+"nFq" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "nFr" = (
 /obj/machinery/door_buttons/access_button{
 	idDoor = "asylum_airlock_exterior";
@@ -44231,6 +44444,13 @@
 /obj/item/bedsheet/blue/double,
 /turf/open/floor/carpet/royalblue,
 /area/commons/dorms/room4)
+"nIB" = (
+/obj/effect/turf_decal/stripes{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "nIE" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -45800,6 +46020,12 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/pod/light,
 /area/maintenance/solars/port/aft)
+"ogA" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/spawner/random/structure/tank_holder,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "ogD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46182,6 +46408,13 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port/fore)
+"olA" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 9
+	},
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "olH" = (
 /obj/structure/table,
 /obj/item/camera,
@@ -46423,6 +46656,11 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/cargo/warehouse)
+"ooQ" = (
+/obj/structure/closet/firecloset,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "ooW" = (
 /obj/structure/table,
 /obj/item/key/security,
@@ -47012,6 +47250,16 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
+"oyN" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 10
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "oyO" = (
 /obj/machinery/power/solar_control{
 	dir = 1;
@@ -47554,6 +47802,9 @@
 	name = "boxing ring"
 	},
 /area/commons/fitness)
+"oHr" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/starboard)
 "oHx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47576,6 +47827,10 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/grass,
 /area/service/chapel)
+"oHL" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "oHN" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -48270,6 +48525,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/science/cytology/lower)
+"oSL" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Bulkhead"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "oST" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 4
@@ -48509,6 +48774,10 @@
 	dir = 1
 	},
 /area/security/brig)
+"oWS" = (
+/obj/effect/spawner/random/engineering/atmospherics_portable,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "oWY" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -49053,11 +49322,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"piJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "piO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49109,6 +49373,11 @@
 /obj/structure/bed,
 /turf/open/floor/iron/white,
 /area/medical/abandoned)
+"pjX" = (
+/obj/structure/ladder,
+/obj/structure/window,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "pka" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -49136,9 +49405,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
-"pkH" = (
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "pkI" = (
 /obj/structure/railing{
 	dir = 6
@@ -49389,6 +49655,9 @@
 /obj/structure/scrap,
 /turf/open/floor/pod/light,
 /area/maintenance/floor4/starboard/fore)
+"pog" = (
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "poo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -49924,6 +50193,11 @@
 	dir = 4
 	},
 /area/hallway/floor1/fore)
+"pxw" = (
+/obj/effect/turf_decal/stripes,
+/obj/effect/decal/cleanable/robot_debris/down,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "pxz" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/structure/window/reinforced/spawner/west,
@@ -50631,7 +50905,10 @@
 /area/maintenance/floor3/starboard/aft)
 "pJs" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "pJu" = (
 /obj/structure/rack/shelf,
@@ -50816,6 +51093,14 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/engineering/atmos/office)
+"pNw" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	icon_state = "floorscorched1"
+	},
+/area/maintenance/floor2/starboard/aft)
 "pNx" = (
 /obj/machinery/portable_atmospherics/canister/halon,
 /turf/open/floor/iron/dark,
@@ -50831,6 +51116,10 @@
 /area/commons/cryo_storage)
 "pNI" = (
 /obj/machinery/power/floodlight,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/maintenance/floor2/starboard/aft)
 "pNK" = (
@@ -51337,16 +51626,6 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating/airless,
 /area/solars/starboard/aft)
-"pXs" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 10
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/emcloset,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "pXL" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/corner,
@@ -51660,6 +51939,10 @@
 "qcG" = (
 /turf/closed/wall,
 /area/cargo/qm)
+"qcP" = (
+/obj/effect/spawner/random/structure/barricade,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "qcQ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -52676,22 +52959,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/maintenance/floor2/starboard)
-"qug" = (
-/obj/effect/turf_decal/trimline/green/warning,
-/obj/effect/spawner/random/structure/table,
-/obj/item/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/assembly/signaler{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/screwdriver{
-	pixel_y = -3
-	},
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "qun" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53425,6 +53692,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/floor3/aft)
+"qEE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "qEF" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter/room)
@@ -54365,11 +54637,6 @@
 /obj/item/clothing/gloves/color/fyellow,
 /turf/open/floor/plating,
 /area/maintenance/floor1/port/fore)
-"qSZ" = (
-/obj/structure/closet/firecloset,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "qTd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -54483,6 +54750,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/solars/starboard/aft)
+"qVe" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "qVf" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -54611,6 +54887,11 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"qWS" = (
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "qXc" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -55207,6 +55488,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/library/private)
+"rgE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard/aft)
 "rgL" = (
 /obj/machinery/door/airlock/service{
 	name = "Minikitchen Access"
@@ -55298,7 +55588,7 @@
 /area/space/nearstation)
 "rif" = (
 /obj/effect/decal/cleanable/robot_debris,
-/turf/open/floor/pod/light,
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "rii" = (
 /obj/structure/sign/poster/official/random/directional/south,
@@ -55733,9 +56023,11 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
 "rrk" = (
-/obj/effect/decal/cleanable/robot_debris/down,
-/obj/item/bodypart/l_arm/robot,
-/turf/open/floor/pod/light,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "rrr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55960,6 +56252,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/command/heads_quarters/captain/private)
+"rvh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "rvn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible/layer2,
@@ -57256,6 +57552,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/lower)
+"rRB" = (
+/obj/effect/turf_decal/stripes,
+/obj/machinery/atmospherics/components/binary/pump/layer4,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "rRP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57888,6 +58189,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"scK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "scP" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/table,
@@ -58116,6 +58422,13 @@
 	icon_state = "floorscorched2"
 	},
 /area/maintenance/floor2/starboard/aft)
+"siJ" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 4
+	},
+/obj/effect/spawner/random/structure/table_or_rack,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "sjr" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -58182,14 +58495,6 @@
 	dir = 4
 	},
 /area/security/prison)
-"skQ" = (
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/door/airlock/hatch{
-	name = "Maintenance Hatch"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "skU" = (
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -58450,7 +58755,7 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/engineering/storage/tech)
 "spr" = (
-/turf/closed/wall/mineral/titanium,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/maintenance/floor2/starboard/aft)
 "spI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59062,6 +59367,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
 /area/faction/survey_wings)
+"syP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard/aft)
 "szn" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -59549,9 +59866,21 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor4/starboard/fore)
 "sHs" = (
-/obj/structure/table,
-/turf/open/floor/iron/dark/red,
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 4
+	},
 /area/security/checkpoint/second)
+"sHv" = (
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/catwalk_floor,
+/area/maintenance/floor2/starboard)
 "sHB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes{
@@ -59750,6 +60079,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/floor3/aft)
+"sKC" = (
+/obj/effect/spawner/structure/window/hollow/middle,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "sKG" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/table,
@@ -59813,6 +60146,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/engine,
 /area/faction/survey_wings)
+"sLl" = (
+/obj/effect/spawner/structure/window/hollow/end,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard)
 "sLq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -59831,7 +60168,6 @@
 /area/hallway/floor2/aft)
 "sLK" = (
 /obj/machinery/airalarm/directional/west,
-/obj/structure/marker_beacon/burgundy,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard/aft)
 "sLL" = (
@@ -60095,6 +60431,13 @@
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
+"sQa" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "sQi" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -60338,11 +60681,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/library/lounge)
-"sTX" = (
-/obj/effect/turf_decal/trimline/green/warning,
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "sTZ" = (
 /turf/open/floor/wood,
 /area/service/theater)
@@ -60533,10 +60871,6 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
-"sWb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/maintenance/floor2/starboard)
 "sWh" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
@@ -60907,6 +61241,9 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/port/fore)
+"tat" = (
+/turf/open/openspace,
+/area/maintenance/floor3/starboard/aft)
 "taD" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -61014,19 +61351,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/floor3/fore)
-"tcH" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/light,
-/area/maintenance/floor2/starboard)
 "tcJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bot_assembly/medbot,
@@ -61094,6 +61418,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/service/theater)
+"tdA" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "tdB" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61163,6 +61500,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"teB" = (
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Atmospheric Substation"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "teN" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark,
@@ -61197,17 +61549,21 @@
 "tfw" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/project)
+"tfE" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "tfJ" = (
 /obj/effect/decal/cleanable/ash,
 /obj/machinery/light/small/broken/directional/north,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
 "tfL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron{
-	icon_state = "floorscorched1"
-	},
-/area/maintenance/floor2/starboard/aft)
+/obj/structure/girder,
+/turf/open/floor/engine/hull/reinforced,
+/area/space)
 "tfS" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/turf_decal/trimline/green/line{
@@ -61253,6 +61609,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science)
+"tgS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/maintenance/floor2/starboard/aft)
 "tha" = (
 /obj/structure/chair{
 	dir = 8;
@@ -61267,6 +61629,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
 /area/service/library/garden)
+"thi" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "thq" = (
 /obj/structure/railing{
 	dir = 5
@@ -61622,6 +61989,17 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron/dark,
 /area/maintenance/floor2/starboard/aft)
+"tnN" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "tnP" = (
 /obj/structure/chair{
 	dir = 4
@@ -62130,6 +62508,11 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/green/side,
 /area/faction/conserve_recycling)
+"twq" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "twx" = (
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
@@ -62567,6 +62950,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
+"tEz" = (
+/obj/structure/sign/poster/official/random/directional/east,
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/iron/dark/red/side{
+	dir = 8
+	},
+/area/security/checkpoint/second)
 "tEG" = (
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor2/starboard/fore)
@@ -62728,6 +63119,12 @@
 /obj/item/toy/figure/hos,
 /turf/open/floor/wood,
 /area/maintenance/floor4/port/aft)
+"tHn" = (
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "tHs" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -62860,6 +63257,9 @@
 /turf/open/floor/iron,
 /area/service/bar)
 "tIT" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
 /turf/open/floor/iron{
 	icon_state = "damaged2"
 	},
@@ -63337,6 +63737,10 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/starboard/fore)
+"tQM" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "tQV" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/radio/intercom/directional/south,
@@ -63772,14 +64176,6 @@
 	dir = 1
 	},
 /area/medical/surgery/aft)
-"tYR" = (
-/obj/structure/cable/layer3,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/starboard)
 "tYU" = (
 /obj/structure/sink{
 	pixel_y = 22
@@ -64106,6 +64502,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor3/port/fore)
+"ueC" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/maintenance/floor2/starboard/aft)
 "ueJ" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -64298,6 +64701,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uhu" = (
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/spawner/random/structure/table,
+/obj/item/assembly/igniter{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/assembly/signaler{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/screwdriver{
+	pixel_y = -3
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "uhx" = (
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/aft)
@@ -64366,7 +64785,12 @@
 /area/service/hydroponics)
 "uiH" = (
 /obj/structure/window/reinforced,
-/turf/open/floor/iron/dark/red,
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/red/side{
+	dir = 6
+	},
 /area/security/checkpoint/second)
 "uiM" = (
 /obj/structure/table/wood,
@@ -65183,6 +65607,13 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/hallway/floor1/fore)
+"uyL" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "uyX" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65240,6 +65671,14 @@
 	dir = 4
 	},
 /area/maintenance/floor2/starboard)
+"uzB" = (
+/obj/structure/table/reinforced,
+/obj/item/screwdriver,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 8
+	},
+/area/maintenance/floor2/starboard/aft)
 "uzE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -65784,6 +66223,16 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/service/kitchen/diner)
+"uJi" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "uJp" = (
 /obj/machinery/button/ec_glass{
 	id = "viroprivacy";
@@ -65931,13 +66380,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"uLh" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "uLj" = (
 /obj/structure/railing/corner,
 /obj/effect/decal/cleanable/dirt,
@@ -66891,13 +67333,6 @@
 	dir = 8
 	},
 /area/security/office)
-"uYO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
 "uYT" = (
 /obj/structure/window/plasma/spawner/north,
 /obj/structure/window/plasma/spawner/west,
@@ -67368,6 +67803,15 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/hydroponics)
+"vhq" = (
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron{
+	icon_state = "floorscorched2"
+	},
+/area/maintenance/floor2/starboard/aft)
 "vhB" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
@@ -67977,6 +68421,15 @@
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/plating,
 /area/maintenance/floor1/starboard)
+"vqQ" = (
+/obj/effect/turf_decal/stripes{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "vqS" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -68327,6 +68780,14 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/starboard)
+"vwN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/valve/layer4{
+	name = "distro access";
+	dir = 8
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/maintenance/floor2/starboard/aft)
 "vxf" = (
 /obj/item/holosign_creator/atmos,
 /turf/open/floor/iron{
@@ -69173,13 +69634,10 @@
 /obj/item/seeds/cannabis,
 /turf/open/floor/iron,
 /area/maintenance/floor1/port/aft)
-"vMH" = (
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/pod/dark,
-/area/maintenance/floor2/starboard)
+"vMF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "vMK" = (
 /obj/machinery/atmospherics/components/binary/crystallizer{
 	dir = 4
@@ -70093,7 +70551,8 @@
 "wbx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/pod/light,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron,
 /area/maintenance/floor2/starboard/aft)
 "wbL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -70662,6 +71121,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/surgery/fore)
+"wky" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "wkz" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -71766,6 +72232,11 @@
 /area/service/theater)
 "wBg" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/robot_debris/up,
+/obj/item/assembly/prox_sensor,
+/obj/structure/shuttle/engine/propulsion/in_wall{
+	dir = 8
+	},
 /turf/open/floor/iron{
 	icon_state = "floorscorched2"
 	},
@@ -71814,13 +72285,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/chapel)
-"wCa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/shard,
-/turf/open/floor/catwalk_floor,
-/area/maintenance/floor2/starboard)
 "wCb" = (
 /obj/structure/window/reinforced/fulltile/ec_glass{
 	id = "orprivacy_b"
@@ -72664,6 +73128,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/floor3/aft)
+"wOv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "wOy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/line{
@@ -72748,6 +73219,12 @@
 	dir = 1
 	},
 /area/hallway/floor2/aft)
+"wQA" = (
+/obj/machinery/door/window/brigdoor/right/directional/east{
+	req_access_txt = "12"
+	},
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard/aft)
 "wQC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73570,6 +74047,10 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/iron/kitchen,
 /area/service/kitchen/diner)
+"xcw" = (
+/obj/machinery/shieldgen,
+/turf/open/floor/plating,
+/area/maintenance/floor2/starboard/aft)
 "xcN" = (
 /obj/structure/railing{
 	dir = 1
@@ -75002,6 +75483,13 @@
 	},
 /turf/open/floor/iron,
 /area/medical/chemistry)
+"xyM" = (
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "xyS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -75846,6 +76334,11 @@
 "xMA" = (
 /turf/closed/wall,
 /area/science/genetics)
+"xMC" = (
+/obj/effect/spawner/random/maintenance,
+/obj/structure/rack/shelf,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard/aft)
 "xMF" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -75944,6 +76437,16 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/engineering/atmos/hfr_room)
+"xOC" = (
+/obj/structure/table/reinforced,
+/obj/structure/sign/poster/contraband/surveywings{
+	pixel_y = 32
+	},
+/obj/item/modular_computer/laptop,
+/obj/item/computer_hardware/hard_drive,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/blue/corner,
+/area/maintenance/floor2/starboard/aft)
 "xOF" = (
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
@@ -76285,6 +76788,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/floor1/port)
+"xVt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "xVC" = (
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor1/fore)
@@ -76519,6 +77026,13 @@
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor1/aft)
+"xYQ" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/landmark/blobstart,
+/turf/open/floor/pod/dark,
+/area/maintenance/floor2/starboard)
 "xYS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -76565,6 +77079,17 @@
 	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
+"xZl" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/warning,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/maintenance/floor2/starboard)
 "xZp" = (
 /turf/closed/wall,
 /area/cargo/sorting)
@@ -176620,7 +177145,7 @@ vnK
 vnK
 uBW
 nCd
-tYR
+sHv
 cBv
 kRS
 kRS
@@ -178421,7 +178946,7 @@ ndL
 vnK
 vaC
 dUU
-tcH
+tdA
 dnJ
 cTJ
 wvg
@@ -178680,7 +179205,7 @@ gns
 fcz
 wGl
 wGl
-bqi
+xZl
 lba
 iOA
 usZ
@@ -179450,7 +179975,7 @@ lCR
 vnK
 vnK
 vnK
-eDt
+uJi
 vnK
 vnK
 iOA
@@ -179703,11 +180228,11 @@ vnK
 vnK
 fdr
 vnK
-dWA
-kpw
+oHr
+bXh
 vnK
-sTX
-kgY
+jUJ
+iDh
 vnK
 dVf
 iOA
@@ -179960,11 +180485,11 @@ vnK
 vnK
 wJI
 okI
-dWA
-uLh
+oHr
+uyL
 vnK
-qug
-kgY
+uhu
+iDh
 vnK
 dVf
 iOA
@@ -180216,12 +180741,12 @@ ucA
 vnK
 vnK
 wJI
-cUS
+olA
 vnK
 vnK
 vnK
-fnp
-fqM
+ogA
+nFq
 vnK
 dVf
 iOA
@@ -180477,8 +181002,8 @@ fov
 vnK
 fvR
 vnK
-gOb
-cfp
+sLl
+qcP
 vnK
 dVf
 dVf
@@ -180729,13 +181254,13 @@ ucA
 ucA
 vnK
 vnK
-wCa
-vMH
+nmK
+wky
 vnK
-dpW
-aEl
-cNJ
-pkH
+tnN
+xYQ
+pjX
+pog
 vnK
 vnK
 vnK
@@ -180987,15 +181512,15 @@ ucA
 vnK
 vnK
 wJI
-aPP
-skQ
-piJ
-sWb
-sWb
-piJ
-piJ
-gxj
-fke
+xyM
+kMk
+gFO
+bAP
+bAP
+gFO
+gFO
+xVt
+gEL
 vnK
 dVf
 iOA
@@ -181246,12 +181771,12 @@ vnK
 wJI
 vnK
 vnK
-fqd
-ejr
-pXs
-qSZ
+qVe
+ejI
+oyN
+ooQ
 wug
-piJ
+gFO
 vnK
 vnK
 vnK
@@ -181508,7 +182033,7 @@ vnK
 vnK
 vnK
 vnK
-hty
+kEY
 vnK
 dVf
 vnK
@@ -181763,10 +182288,10 @@ vnK
 dVf
 dVf
 dVf
-ihb
-ljp
-uYO
-ihb
+sKC
+fCx
+wOv
+sKC
 dVf
 vnK
 jTG
@@ -182022,7 +182547,7 @@ vnK
 vnK
 vnK
 vnK
-dai
+oSL
 vnK
 vnK
 vnK
@@ -182271,11 +182796,11 @@ ucA
 ucA
 dEt
 dEt
-cGu
+gTs
 opN
 dEt
-drJ
-drJ
+ehA
+siJ
 dEt
 wgj
 avs
@@ -182530,9 +183055,9 @@ dEt
 dEt
 wWk
 opN
-dEt
-drJ
-drJ
+wuA
+mPw
+mPw
 dEt
 wgj
 wgj
@@ -182785,11 +183310,11 @@ ucA
 ucA
 dEt
 dEt
-cGu
-opN
+thi
+wQA
 dEt
 drJ
-drJ
+mPw
 dEt
 aqS
 gxJ
@@ -183043,9 +183568,9 @@ ucA
 dEt
 dEt
 cGu
-opN
-wuA
-mPw
+cGu
+dEt
+xMC
 mPw
 dEt
 wgj
@@ -183303,7 +183828,7 @@ dEt
 dEt
 dEt
 dEt
-mPw
+kkI
 dEt
 wgj
 wgj
@@ -183560,7 +184085,7 @@ dEt
 dEt
 dEt
 dEt
-mPw
+hgQ
 dEt
 arC
 cpu
@@ -183811,13 +184336,13 @@ ucA
 ucA
 ucA
 ucA
-dkh
+tfL
 dkh
 dkh
 dkh
 dEt
 dEt
-mPw
+mcp
 dEt
 avl
 wgj
@@ -184072,10 +184597,10 @@ dkh
 dkh
 dkh
 dkh
-dEt
-dEt
-mPw
-dEt
+tFm
+tFm
+tgS
+tFm
 avl
 wgj
 ybi
@@ -184329,14 +184854,14 @@ dkh
 dkh
 dkh
 dkh
-dEt
-dEt
-mPw
-dEt
+tFm
+tFm
+tgS
+tFm
 pvZ
 aqS
 mDr
-bXx
+jko
 vss
 ojz
 mcB
@@ -184586,10 +185111,10 @@ dkh
 dkh
 dkh
 dkh
-dEt
-dEt
-mPw
-dEt
+tFm
+tFm
+tgS
+tFm
 wgj
 cpu
 lEi
@@ -184845,7 +185370,7 @@ dkh
 dkh
 dEt
 dEt
-mPw
+mcp
 dEt
 aqS
 xRp
@@ -185096,13 +185621,13 @@ ucA
 ucA
 ucA
 ucA
-dkh
+myO
 dkh
 dkh
 dkh
 dEt
 dEt
-mPw
+gqJ
 dEt
 dEt
 dEt
@@ -185359,13 +185884,13 @@ dkh
 dkh
 dEt
 dEt
-mPw
+kkI
 mlx
 cvg
 hkz
 pOH
 pJA
-pJs
+ipu
 aUe
 dEt
 aPc
@@ -185618,7 +186143,7 @@ dEt
 dEt
 mPw
 pNI
-pJA
+dxK
 kki
 dxK
 dxK
@@ -185871,16 +186396,16 @@ dkh
 dkh
 dkh
 dkh
-dEt
-dEt
+tFm
+jPg
 mPw
 eHk
 meB
 fxm
-ehA
+pJA
 wBg
-drJ
-drJ
+kgY
+axf
 dEt
 dEt
 uZF
@@ -186129,13 +186654,13 @@ dkh
 dkh
 dkh
 dEt
-dEt
+kJU
 mPw
+sQa
 spr
 spr
 del
 spr
-dxK
 jFB
 pJs
 rif
@@ -186381,19 +186906,19 @@ ucA
 ucA
 ucA
 ucA
-dkh
+myO
 dkh
 dkh
 dkh
 dEt
-dEt
+xcw
 mPw
+sQa
 spr
 aOa
 vyv
 spr
-fXq
-drJ
+pxw
 rrk
 awA
 jBf
@@ -186643,20 +187168,20 @@ dkh
 dkh
 dkh
 dEt
-dEt
+fXq
 mPw
+pNw
 spr
 aOa
 xpt
 spr
-dxK
-dEt
-dEt
+kgY
+kJU
 dEt
 dEt
 uZF
-uZF
-uZF
+tEz
+lyR
 uZF
 uZF
 uZF
@@ -186899,21 +187424,21 @@ dkh
 dkh
 dkh
 dkh
-dEt
-dEt
+tFm
+oHL
 mPw
+vhq
 spr
 aOa
 xpt
 spr
-tfL
+gri
+fkD
 dEt
-drJ
-mPw
-mPw
-mPw
-mPw
-mPw
+lYb
+uZF
+uZF
+uZF
 uZF
 oDG
 svu
@@ -187159,17 +187684,17 @@ dkh
 dEt
 dEt
 mPw
+sQa
 spr
 kSX
 kSX
 spr
-dxK
-dEt
-drJ
+kgY
 mPw
-dEt
-loM
-dEt
+hSI
+mPw
+mPw
+mPw
 mPw
 uZF
 svu
@@ -187418,15 +187943,15 @@ dEt
 mPw
 tIT
 siG
-pJA
+dxK
 pJA
 dxK
-dEt
+kgY
 mPw
-mPw
 dEt
-drJ
-dEt
+ejr
+bET
+kFp
 mPw
 uZF
 svu
@@ -187673,12 +188198,12 @@ dkh
 dEt
 dEt
 mPw
-dEt
-dEt
-dEt
-dEt
-dEt
-dEt
+dge
+bRI
+ueC
+ueC
+bRI
+nIB
 mPw
 dEt
 dEt
@@ -187930,16 +188455,16 @@ dkh
 dEt
 dEt
 mPw
+mPw
+mPw
+mPw
+isk
+syP
+rgE
+mPw
 dEt
-drJ
-drJ
-drJ
-mPw
-mPw
-mPw
-dEt
-drJ
-drJ
+lgO
+vwN
 dEt
 mPw
 uZF
@@ -188186,17 +188711,17 @@ dkh
 dkh
 dEt
 dEt
-mPw
+tQM
+gUf
+aeb
 dEt
-drJ
-drJ
-drJ
-mPw
+gFS
+fXq
+dEt
+ius
 dEt
 dEt
-dEt
-drJ
-drJ
+teB
 dEt
 mPw
 uZF
@@ -188443,17 +188968,17 @@ dkh
 dkh
 dEt
 dEt
-mPw
+xOC
+hjP
+jRW
+nBO
+fIM
+fXq
 dEt
-mPw
-mPw
-mPw
-mPw
-dEt
-drJ
-drJ
-drJ
-drJ
+jNP
+jNP
+rRB
+fOK
 dEt
 mPw
 uZF
@@ -188700,17 +189225,17 @@ dkh
 dkh
 dEt
 dEt
-mPw
-mPw
-mPw
+ioZ
+uzB
+fpt
 dEt
+tfE
+fXq
 dEt
-dEt
-dEt
-dEt
-drJ
-drJ
-drJ
+jNP
+jNP
+gOp
+qEE
 dEt
 mPw
 uZF
@@ -188951,23 +189476,23 @@ ucA
 ucA
 ucA
 ucA
+myO
 dkh
 dkh
 dkh
-dkh
 dEt
 dEt
 dEt
 dEt
 dEt
 dEt
-drJ
-drJ
-drJ
 dEt
-drJ
-drJ
-drJ
+jPg
+dEt
+jNP
+twq
+vqQ
+fOK
 dEt
 mPw
 uZF
@@ -189211,24 +189736,24 @@ ucA
 dkh
 dkh
 dkh
-dkh
+tfL
 dEt
 dEt
 dEt
 dEt
 dEt
 dEt
-drJ
-drJ
-drJ
-drJ
-drJ
-drJ
-drJ
+fXq
+vMF
+jas
+cOD
+lXn
+scK
+qEE
 dEt
 mPw
-drJ
-kkI
+imI
+wWk
 uZF
 svu
 uZF
@@ -189475,17 +190000,17 @@ dkh
 dkh
 dEt
 dEt
-drJ
-drJ
-drJ
-dEt
-drJ
-drJ
-drJ
+fXq
+rvh
+bwK
+tHn
+qWS
+aZA
+hsW
 dEt
 mPw
-drJ
-drJ
+imI
+aBx
 uZF
 svu
 uZF
@@ -189741,8 +190266,8 @@ dEt
 dEt
 dEt
 mPw
-drJ
-drJ
+imI
+oWS
 uZF
 svu
 gSu
@@ -189988,7 +190513,7 @@ dkh
 dkh
 dEt
 dEt
-drJ
+jPg
 dEt
 mSR
 qKl
@@ -193611,7 +194136,7 @@ nUJ
 dkh
 dkh
 nUJ
-dkh
+imY
 dkh
 dkh
 dkh
@@ -253470,8 +253995,8 @@ cCk
 qjq
 eJc
 jOT
-cIM
-hSc
+oxP
+aZI
 kRw
 kRw
 kRw
@@ -253727,8 +254252,8 @@ ief
 lrM
 qON
 tYW
-cIM
-cIM
+tat
+kYv
 cIM
 cIM
 cIM
@@ -253984,8 +254509,8 @@ hci
 oyO
 uPA
 tYW
-cIM
-dyq
+tat
+kYv
 kRw
 dyq
 kRw
@@ -254241,8 +254766,8 @@ lKj
 tYW
 keM
 tYW
-cIM
-cIM
+tat
+kYv
 cIM
 cIM
 cIM


### PR DESCRIPTION
(This is just a small preview; the changes have ballooned out to the rest of deck two and briefly touched each of the other decks as well)
![image](https://user-images.githubusercontent.com/50649185/182242922-7801ec3f-fb77-4b15-aabe-c4288018813b.png)

:cl:
add: The second deck's maint has been fixed up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
