### PR TITLE
Port Gives AI displays "proper" multiz support

### DIFF
--- a/code/__HELPERS/levels.dm
+++ b/code/__HELPERS/levels.dm
@@ -1,0 +1,19 @@
+/**
+ * - is_valid_z_level
+ *
+ * Checks if source_loc and checking_loc is both on the station, or on the same z level.
+ * This is because the station's several levels aren't considered the same z, so multi-z stations need this special case.
+ *
+ * Args:
+ * source_loc - turf of the source we're comparing.
+ * checking_loc - turf we are comparing to source_loc.
+ *
+ * returns TRUE if connection is valid, FALSE otherwise.
+ */
+/proc/is_valid_z_level(turf/source_loc, turf/checking_loc)
+	// if we're both on "station", regardless of multi-z, we'll pass by.
+	if(is_station_level(source_loc.z) && is_station_level(checking_loc.z))
+		return TRUE
+	if(source_loc.z == checking_loc.z)
+		return TRUE
+	return FALSE

--- a/code/modules/mob/living/silicon/ai/emote.dm
+++ b/code/modules/mob/living/silicon/ai/emote.dm
@@ -14,13 +14,12 @@
 	var/mob/living/silicon/ai/ai = user
 	var/turf/ai_turf = get_turf(ai)
 
-	for(var/_display in GLOB.ai_status_displays)
-		var/obj/machinery/status_display/ai/ai_display = _display
+	for(var/obj/machinery/status_display/ai/ai_display as anything in GLOB.ai_status_displays)
 		var/turf/display_turf = get_turf(ai_display)
 
-		// Derelict AIs can't affect station displays.
-		// TODO does this need to be made multiZ aware?
-		if(ai_turf.z != display_turf.z)
+		// - Station AIs can change every display on the station Z.
+		// - Ghost role AIs (or AIs on the mining base?) can only affect their Z
+		if(!is_valid_z_level(ai_turf, display_turf))
 			continue
 
 		ai_display.emotion = emotion

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -306,6 +306,7 @@
 #include "code\__HELPERS\icons.dm"
 #include "code\__HELPERS\jatum.dm"
 #include "code\__HELPERS\level_traits.dm"
+#include "code\__HELPERS\levels.dm"
 #include "code\__HELPERS\lighting.dm"
 #include "code\__HELPERS\maths.dm"
 #include "code\__HELPERS\matrices.dm"


### PR DESCRIPTION
## About The Pull Request

Port [tgstation/#68864](https://github.com/tgstation/tgstation/pull/68864)

## Why It's Good For The Game

The main map played is multi-z

## Changelog

:cl: Melbert
qol: AIs which update their status displays on multi-z station maps will now update ALL displays on station, instead of only those which match the level their core is on
/:cl:
