### PR TITLE
Faction Selection System

### DIFF
--- a/code/modules/client/preferences/access_preference.dm
+++ b/code/modules/client/preferences/access_preference.dm
@@ -106,5 +106,10 @@ Remember that, when adding new preferences, you also need to add a corresponding
 
 */
 
+/datum/preference/choiced/access/bonus_access
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "bonus_access"
+	keys_to_access = list("Additional Access" = ACCESS_UNITY)
+
 #undef NO_EXTRA_ACCESS
 #undef NO_EXTRA_ACCESS_KEY

--- a/code/modules/client/preferences/access_preference.dm
+++ b/code/modules/client/preferences/access_preference.dm
@@ -1,5 +1,5 @@
 #define NO_EXTRA_ACCESS -1
-#define NO_EXTRA_ACCESS_KEY "No Faction"
+#define NO_EXTRA_ACCESS_KEY "No Extra Access"
 
 /// Allowss you to make a preference for starting with additional roundstart access
 /// Contains a smidge of hackery to function before SSid_access is instantiated

--- a/code/modules/client/preferences/access_preference.dm
+++ b/code/modules/client/preferences/access_preference.dm
@@ -1,5 +1,5 @@
 #define NO_EXTRA_ACCESS -1
-#define NO_EXTRA_ACCESS_KEY "No Extra Access"
+#define NO_EXTRA_ACCESS_KEY "No Faction"
 
 /// Allowss you to make a preference for starting with additional roundstart access
 /// Contains a smidge of hackery to function before SSid_access is instantiated
@@ -109,7 +109,7 @@ Remember that, when adding new preferences, you also need to add a corresponding
 /datum/preference/choiced/access/bonus_access
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "bonus_access"
-	keys_to_access = list("Additional Access" = ACCESS_UNITY)
+	keys_to_access = list("The Unity" = ACCESS_UNITY, "The Home Guard" = ACCESS_HOME_GUARD, "Mekhane" = ACCESS_MEKHANE, "Conservators" = ACCESS_CONSERVATORS, "Chiron Biolabs" = ACCESS_CHIRON_BIOLABS)
 
 #undef NO_EXTRA_ACCESS
 #undef NO_EXTRA_ACCESS_KEY

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/access_choice/bonus_access.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/access_choice/bonus_access.tsx
@@ -1,6 +1,6 @@
 import { Feature, FeatureDropdownInput } from "../../base";
 
-export const unity_access: Feature<number> = {
-  name: "The Unity",
+export const bonus_access: Feature<number> = {
+  name: "Faction Choice",
   component: FeatureDropdownInput,
 }

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/access_choice/bonus_access.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/access_choice/bonus_access.tsx
@@ -1,6 +1,6 @@
-import { Feature, FeatureDropdownInput } from "../../base";
+import { FeatureChoiced, FeatureDropdownInput } from "../../base";
 
-export const bonus_access: Feature<number> = {
+export const bonus_access: FeatureChoiced = {
   name: "Faction Choice",
   component: FeatureDropdownInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/access_choice/bonus_access.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/access_choice/bonus_access.tsx
@@ -3,4 +3,4 @@ import { Feature, FeatureDropdownInput } from "../../base";
 export const bonus_access: Feature<number> = {
   name: "Faction Choice",
   component: FeatureDropdownInput,
-}
+};

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/access_choice/unity_access.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/access_choice/unity_access.tsx
@@ -1,0 +1,6 @@
+import { Feature, FeatureDropdownInput } from "../../base";
+
+export const unity_access: Feature<number> = {
+  name: "The Unity",
+  component: FeatureDropdownInput,
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Using the framework and access provided, you can now select your character's faction, which gives them access to their faction's station home and whatever perks that may come with it.
![image](https://user-images.githubusercontent.com/73589390/183531980-a257f7db-da79-47bc-8fe1-01eb4d0c56ed.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The North Star's factions are ready to get factioning! This is an important + major feature for both lore and gameplay, and will allow us to expand on character creation!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The North Star's crew have once again been given access to their Faction's HQ.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
