### PR TITLE
Fixes Greyscale Beret Loadout Items

### DIFF
--- a/starbloom_modules/code/modules/loadouts/loadout_items/loadout_datum_heads.dm
+++ b/starbloom_modules/code/modules/loadouts/loadout_items/loadout_datum_heads.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 
 /datum/loadout_item/head/greyscale_beret/badge
 	name = "Greyscale Beret (with badge)"
-	item_path = /obj/item/clothing/head/beret/greyscale
+	item_path = /obj/item/clothing/head/beret/greyscale_badge
 
 /datum/loadout_item/head/black_beret
 	name = "Black Beret"


### PR DESCRIPTION
Someone fucked up with a copy-paste lmao 

:cl:
fix: The badged greyscale beret now correctly applies in the loadout.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
