### PR TITLE
Obesity Tweaks and MRE fix

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -171,8 +171,8 @@
 
 
 /atom/movable/screen/alert/fat
-	name = "Fat"
-	desc = "You ate too much food, lardass. Run around the station and lose some weight."
+	name = "Overindulged"
+	desc = "You ate too much food. See medical for help, or visit the rec room on Habitation."
 	icon_state = "fat"
 
 /atom/movable/screen/alert/hungry

--- a/code/datums/mood_events/needs_events.dm
+++ b/code/datums/mood_events/needs_events.dm
@@ -1,6 +1,6 @@
 //nutrition
 /datum/mood_event/fat
-	description = "<B>I'm so fat...</B>" //muh fatshaming
+	description = "I feel like I ate too much..."
 	mood_change = -6
 
 /datum/mood_event/wellfed

--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -297,7 +297,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("meat" = 1)
 	foodtypes = MEAT | RAW
-	eatverbs = list("bite", "chew", "nibble", "deep throat", "gobble", "chomp")
+	eatverbs = list("bite", "chew", "nibble", "gobble", "chomp")
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/raw_sausage/MakeGrillable()
@@ -311,7 +311,7 @@
 	tastes = list("meat" = 1)
 	foodtypes = MEAT | BREAKFAST
 	food_flags = FOOD_FINGER_FOOD
-	eatverbs = list("bite", "chew", "nibble", "deep throat", "gobble", "chomp")
+	eatverbs = list("bite", "chew", "nibble", "gobble", "chomp")
 	w_class = WEIGHT_CLASS_SMALL
 	burns_on_grill = TRUE
 	venue_value = FOOD_PRICE_CHEAP

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2081,7 +2081,6 @@
 			to_chat(src, span_notice("Your transformation restores your body's natural fitness!"))
 
 		REMOVE_TRAIT(src, TRAIT_FAT, OBESITY)
-		remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
 		update_inv_w_uniform()
 		update_inv_wear_suit()
 

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -1,6 +1,3 @@
-/datum/movespeed_modifier/obesity
-	multiplicative_slowdown = 1.5
-
 /datum/movespeed_modifier/monkey_reagent_speedmod
 	variable = TRUE
 

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -124,14 +124,12 @@
 		if(human.overeatduration < (200 SECONDS))
 			to_chat(human, span_notice("You feel fit again!"))
 			REMOVE_TRAIT(human, TRAIT_FAT, OBESITY)
-			human.remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
 			human.update_inv_w_uniform()
 			human.update_inv_wear_suit()
 	else
 		if(human.overeatduration >= (200 SECONDS))
-			to_chat(human, span_danger("You suddenly feel blubbery!"))
+			to_chat(human, span_danger("You feel like you ate too much..."))
 			ADD_TRAIT(human, TRAIT_FAT, OBESITY)
-			human.add_movespeed_modifier(/datum/movespeed_modifier/obesity)
 			human.update_inv_w_uniform()
 			human.update_inv_wear_suit()
 

--- a/modular_skyrat/modules/mre_vendor/code/game/objects/items/storage/boxes.dm
+++ b/modular_skyrat/modules/mre_vendor/code/game/objects/items/storage/boxes.dm
@@ -5,6 +5,13 @@
 	icon_state = "mre"
 	var/unheated = TRUE
 
+/obj/item/storage/box/mre/attack_hand(mob/user)
+	. = ..()
+	if(unheated)
+		unheated = FALSE
+		to_chat(user, span_notice("The [src] hisses softly, its internal chemical heater heating up the food inside."))
+		playsound(loc, 'sound/effects/fuse.ogg', 50, 1)
+
 /obj/item/storage/box/mre/AltClick(mob/user)
 	. = ..()
 	if(unheated)
@@ -258,7 +265,7 @@
 
 /obj/item/storage/box/mre/mre_continental/PopulateContents()
 	new	/obj/item/food/baguette(src)
-	new	/obj/item/food/cheese(src)
+	new	/obj/item/food/cheese/wedge(src)
 	new	/obj/item/food/chococornet(src)
 	new	/obj/item/food/donut/jelly/plain(src)
 	new	/obj/item/food/branrequests(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the 50% slow from obesity. Keeps the mood debuff. Rethemes obesity to just be overeating - when was the last time you needed a mobility scooter after a singular donut?

Also makes MREs hiss when you open them, this was broken functionality from when I coded them originally. Removes the deepthroat option from sausages. Fuck atomisation.

## Why It's Good For The Game

With our lower hunger rates, overeating is way more punishing than it was designed to be.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: removes slow from obesity
fix: fixes broken sound on MRE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
