### PR TITLE
Post Test Map Fixes 10 + Tweaks + Spaghetti the Atmos Penguin

### DIFF
--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -931,10 +931,22 @@
 	},
 /area/maintenance/solars/starboard/fore)
 "amn" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/recharge_station,
-/obj/structure/window/spawner/east,
-/turf/open/floor/iron,
+/obj/structure/table/reinforced,
+/obj/structure/window/spawner,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 1
+	},
+/obj/item/stock_parts/matter_bin{
+	pixel_x = 2;
+	pixel_y = -5
+	},
+/obj/item/stock_parts/micro_laser{
+	pixel_y = 7
+	},
+/obj/item/trash/boritos/green,
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
 /area/engineering/lobby)
 "ams" = (
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -3206,7 +3218,11 @@
 /turf/open/floor/wood/large,
 /area/service/library/lounge)
 "aQJ" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/structure/table,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/glasses/meson/engine/tray,
+/obj/item/clothing/glasses/meson/engine/tray,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aQK" = (
@@ -4491,6 +4507,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/corner,
 /area/engineering/lobby)
 "bhv" = (
@@ -5866,7 +5883,9 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
 "bwl" = (
-/obj/machinery/door/airlock/highsecurity,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Engine Access"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -7422,7 +7441,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/commons/dorms/room4)
 "bRZ" = (
-/obj/machinery/door/airlock/maintenance/external,
+/obj/machinery/door/airlock/maintenance/external{
+	name = "Ports To Supermatter"
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -8665,6 +8686,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/tcommsat/server)
 "cjM" = (
@@ -11511,7 +11533,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engineering/atmos/storage/gas)
 "dbK" = (
 /obj/structure/cable,
@@ -13414,6 +13436,7 @@
 /area/engineering/lobby)
 "dFT" = (
 /obj/machinery/airalarm/directional/west,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/side,
 /area/engineering/lobby)
 "dFZ" = (
@@ -13485,7 +13508,9 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/hallway/floor1/aft)
 "dHg" = (
-/obj/machinery/pipedispenser,
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dHl" = (
@@ -13917,7 +13942,12 @@
 /obj/structure/bed/double,
 /obj/item/bedsheet/captain/double,
 /obj/effect/landmark/start/captain,
-/obj/machinery/requests_console/directional/east,
+/obj/machinery/requests_console/directional/east{
+	announcementConsole = 1;
+	department = "Captain's Office";
+	departmentType = 5;
+	name = "Captain's Request Console"
+	},
 /turf/open/floor/wood/tile,
 /area/command/heads_quarters/captain/private)
 "dNn" = (
@@ -14354,7 +14384,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
 	dir = 5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engineering/atmos/storage/gas)
 "dUr" = (
 /obj/structure/disposalpipe/junction{
@@ -15031,6 +15061,7 @@
 /area/service/kitchen/diner)
 "efp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
 "efr" = (
@@ -15502,14 +15533,12 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port)
 "emj" = (
-/obj/machinery/computer/security{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/corner,
+/obj/structure/chair/office{
+	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark/red/side{
-	dir = 9
-	},
-/area/security/checkpoint/engineering)
+/turf/open/floor/iron/corner,
+/area/engineering/lobby)
 "emk" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /obj/structure/disposalpipe/segment,
@@ -15575,7 +15604,7 @@
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
 	pixel_y = -24;
-	req_access_txt = "39"
+	req_access = list("virology")
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -15583,6 +15612,10 @@
 /obj/effect/turf_decal/arrows/white{
 	dir = 8;
 	pixel_y = 16
+	},
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
@@ -16072,6 +16105,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/lobby)
 "evn" = (
@@ -20879,6 +20913,7 @@
 	dir = 4;
 	pixel_y = 16
 	},
+/obj/machinery/camera/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "fWh" = (
@@ -21339,6 +21374,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
+"gdd" = (
+/mob/living/simple_animal/pet/penguin/emperor{
+	desc = "Spaghetti.";
+	name = "Spaghetti"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gdg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -21349,15 +21391,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gdk" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor/right/directional/south{
-	name = "Security Desk";
-	req_access = list("security")
-	},
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/checkpoint/engineering)
+/area/engineering/lobby)
 "gdA" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/turf_decal/bot,
@@ -21487,11 +21524,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark/textured_large,
 /area/faction/mekhane_workshop)
-"gfs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/engineering)
 "gfv" = (
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -22002,7 +22034,9 @@
 /turf/open/floor/pod/dark,
 /area/maintenance/floor2/starboard)
 "gnx" = (
-/obj/machinery/door/airlock/highsecurity,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Atmos Access"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -22577,7 +22611,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
 	dir = 5
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engineering/atmos/storage/gas)
 "gxB" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners{
@@ -22851,6 +22885,18 @@
 "gBT" = (
 /turf/closed/wall,
 /area/commons/storage/tools)
+"gBX" = (
+/obj/effect/turf_decal/trimline/blue/corner,
+/obj/structure/window/spawner/east,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/iron/corner{
+	dir = 8
+	},
+/area/engineering/lobby)
 "gCj" = (
 /turf/open/floor/iron/dark/green/side{
 	dir = 8
@@ -27820,6 +27866,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
 "hYU" = (
@@ -28072,14 +28119,14 @@
 /area/maintenance/solars/starboard/aft)
 "ieh" = (
 /obj/docking_port/stationary{
+	dheight = 1;
+	dir = 8;
 	dwidth = 5;
 	height = 8;
 	id = "mining_home";
 	name = "salvage shuttle bay";
 	roundstart_template = /datum/map_template/shuttle/mining/northpoint;
-	width = 10;
-	dir = 8;
-	dheight = 1
+	width = 10
 	},
 /turf/open/floor/engine,
 /area/cargo/miningdock)
@@ -28737,13 +28784,6 @@
 	},
 /turf/open/floor/iron/dark/red/corner,
 /area/security/warden)
-"inp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/window/right/directional/west{
-	name = "Order Window"
-	},
-/turf/open/floor/iron,
-/area/hallway/floor1/aft)
 "inq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/toy/nuke,
@@ -28985,19 +29025,19 @@
 	id = "hopline";
 	name = "Queue Shutters Control";
 	pixel_y = -6;
-	req_access_txt = "57"
+	req_access = list("hop")
 	},
 /obj/machinery/button/door/directional/west{
 	id = "hopblast";
 	name = "Lockdown Blast Doors";
 	pixel_y = 6;
-	req_access_txt = "57"
+	req_access = list("hop")
 	},
 /obj/machinery/button/flasher{
 	id = "hopflash";
 	pixel_x = -38;
 	pixel_y = -7;
-	req_access_txt = "28"
+	req_access = list("hop")
 	},
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 4
@@ -30017,7 +30057,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engineering/atmos/storage/gas)
 "iHc" = (
 /obj/effect/turf_decal/trimline/blue/warning{
@@ -30260,12 +30300,6 @@
 "iLF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	dir = 4;
-	name = "\improper Engine Waste Monitor";
-	network = list("waste");
-	pixel_x = -26
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/storage/gas)
@@ -31245,6 +31279,7 @@
 "jbi" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
+/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
 "jbu" = (
@@ -33035,7 +33070,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engineering/atmos/storage/gas)
 "jBm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33204,7 +33239,9 @@
 /turf/closed/wall,
 /area/engineering/atmos/storage/gas)
 "jEw" = (
-/obj/machinery/computer/department_orders/engineering,
+/obj/machinery/computer/department_orders/engineering{
+	department_delivery_areas = list(/area/engineering/lobby)
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -34125,9 +34162,11 @@
 "jRo" = (
 /obj/effect/mapping_helpers/airlock/access/any/science/minisat,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai_sat"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "External Airlock"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -35916,7 +35955,9 @@
 /turf/open/floor/catwalk_floor,
 /area/hallway/floor3/aft)
 "ksn" = (
-/obj/machinery/pipedispenser/disposal,
+/obj/structure/table,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kso" = (
@@ -36575,6 +36616,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark,
 /area/engineering/lobby)
 "kBL" = (
@@ -36896,7 +36938,6 @@
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/maintenance/club)
 "kGK" = (
-/obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -36906,6 +36947,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Engine Access"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/engineering/storage_shared)
 "kGL" = (
@@ -39435,6 +39479,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
 "lqu" = (
@@ -40905,7 +40950,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer4{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engineering/atmos/storage/gas)
 "lLY" = (
 /obj/structure/safe/floor,
@@ -42649,7 +42694,15 @@
 /area/hallway/floor3/aft)
 "mkd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/corner,
+/obj/structure/table/reinforced,
+/obj/structure/window/spawner,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
 /area/engineering/lobby)
 "mki" = (
 /obj/machinery/airalarm/directional/east,
@@ -42766,7 +42819,8 @@
 /area/command/heads_quarters/rd)
 "mlW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/engine/air,
 /area/engineering/atmos/storage/gas)
 "mlX" = (
 /obj/structure/chair/comfy/brown,
@@ -45608,8 +45662,15 @@
 /turf/open/floor/iron/textured_large,
 /area/engineering/lobby)
 "nag" = (
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/engineering)
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/table/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	name = "Engineering Desk";
+	req_access = list("engineering")
+	},
+/turf/open/floor/plating,
+/area/engineering/lobby)
 "nah" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -47448,12 +47509,6 @@
 /turf/open/floor/mineral/silver,
 /area/service/chapel/funeral)
 "nxX" = (
-/obj/machinery/turretid{
-	icon_state = "control_stun";
-	name = "AI Chamber turret control";
-	pixel_x = 3;
-	pixel_y = -23
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -53142,7 +53197,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "pgG" = (
@@ -55411,9 +55465,11 @@
 /area/hallway/floor3/fore)
 "pPz" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
-/obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/airlock/hatch{
+	name = "Maintenance Access"
+	},
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard/aft)
 "pPC" = (
@@ -55698,6 +55754,17 @@
 /obj/effect/turf_decal/trimline/brown/line,
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
+"pUp" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/engineering/lobby)
 "pUr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55772,16 +55839,10 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
 "pVZ" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 5
-	},
-/obj/effect/landmark/start/depsec/engineering,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/engineering)
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/half,
+/area/engineering/lobby)
 "pWb" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -55924,6 +55985,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
 "pYl" = (
@@ -57507,6 +57569,7 @@
 	dir = 4
 	},
 /obj/structure/fireaxecabinet/directional/north,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
@@ -61469,15 +61532,20 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "rCU" = (
-/obj/machinery/computer/secure_data{
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 10
+/obj/machinery/light/directional/west,
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/iron/five{
+	pixel_x = -6
 	},
-/obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/engineering)
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/engineering/lobby)
 "rCW" = (
 /turf/open/floor/iron/white,
 /area/hallway/floor2/aft)
@@ -61607,12 +61675,15 @@
 /turf/open/floor/iron/dark/side,
 /area/security/brig)
 "rGe" = (
-/obj/machinery/door/airlock/security/old{
-	name = "Engineering Checkpoint"
+/obj/machinery/camera/autoname/directional/west,
+/obj/structure/chair/sofa/bench/right,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/turf/open/floor/iron/dark/red,
-/area/security/checkpoint/engineering)
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/engineering/lobby)
 "rGg" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/three,
@@ -67140,8 +67211,17 @@
 	},
 /area/maintenance/oxygen_recycling)
 "tof" = (
-/turf/closed/wall,
-/area/security/checkpoint/engineering)
+/obj/effect/turf_decal/trimline/blue/corner{
+	dir = 4
+	},
+/obj/structure/chair/sofa/bench/left,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/engineering/lobby)
 "tog" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -68057,6 +68137,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/south,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
@@ -68657,6 +68739,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured_large,
 /area/engineering/lobby)
+"tNA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "tNC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69076,11 +69165,13 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
 "tTI" = (
-/obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/engine_equipment,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/hidden/layer1,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Atmos Access"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/engineering/storage_shared)
 "tTJ" = (
@@ -70360,7 +70451,7 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4{
 	dir = 10
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engineering/atmos/storage/gas)
 "upx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -71653,12 +71744,13 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard/fore)
 "uKL" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/dark/red/side{
-	dir = 6
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 5
 	},
-/area/security/checkpoint/engineering)
+/turf/open/floor/iron/corner{
+	dir = 8
+	},
+/area/engineering/lobby)
 "uKO" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -71927,9 +72019,11 @@
 /area/science/server)
 "uOy" = (
 /obj/effect/mapping_helpers/airlock/access/any/science/minisat,
-/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "ai_sat"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "External Airlock"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -72157,6 +72251,15 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"uSC" = (
+/obj/machinery/turretid{
+	icon_state = "control_stun";
+	name = "AI Chamber turret control";
+	pixel_x = 3;
+	pixel_y = -23
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "uSN" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74215,7 +74318,7 @@
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Button";
 	pixel_y = 24;
-	req_access_txt = "39"
+	req_access = list("virology")
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
@@ -74999,20 +75102,6 @@
 /obj/machinery/light/small/broken/directional/east,
 /turf/open/floor/wood,
 /area/maintenance/floor1/port/fore)
-"vHP" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/obj/machinery/door/window/left/directional/north{
-	name = "Hydroponics Garden";
-	req_access = list("hydroponics")
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "vHQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78134,7 +78223,7 @@
 	c_tag = "Supermatter Waste";
 	network = list("waste")
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engineering/atmos/storage/gas)
 "wBg" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -78453,7 +78542,10 @@
 /obj/structure/sign/warning{
 	pixel_y = 32
 	},
-/obj/machinery/camera/directional/east,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
+	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "wFO" = (
@@ -81502,7 +81594,7 @@
 	idSelf = "virology_airlock_control";
 	name = "Virology Access Console";
 	pixel_x = 24;
-	req_access_txt = "39"
+	req_access_txt = list("virology")
 	},
 /turf/open/floor/iron/dark/green/side{
 	dir = 1
@@ -82545,6 +82637,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/oil,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "xNE" = (
@@ -121436,7 +121529,7 @@ exn
 hHu
 gzO
 oyW
-vHP
+oyW
 wvZ
 kzE
 kzE
@@ -122713,7 +122806,7 @@ bJg
 fxC
 iII
 hbk
-inp
+ibE
 xCk
 ibE
 woP
@@ -124235,7 +124328,7 @@ wMy
 xFJ
 ams
 fbt
-gfW
+gdd
 lBo
 pyS
 gdg
@@ -127081,7 +127174,7 @@ vGx
 eWx
 rFb
 hTS
-nag
+vGx
 nag
 fxB
 iXU
@@ -127338,7 +127431,7 @@ jEw
 nDw
 bhp
 jPh
-gfs
+rFb
 emj
 rCU
 iXU
@@ -127852,9 +127945,9 @@ vGx
 oaW
 rFb
 hTS
-nag
-tof
-tof
+vGx
+gBX
+pUp
 tof
 amn
 plX
@@ -128113,7 +128206,7 @@ nQY
 mLZ
 rcd
 pgE
-plX
+tNA
 rcd
 cQB
 yhO
@@ -327036,7 +327129,7 @@ eus
 fho
 lvO
 nTK
-jgd
+uSC
 vuF
 vuF
 vuF

--- a/_maps/shuttles/cargo_delta.dmm
+++ b/_maps/shuttles/cargo_delta.dmm
@@ -83,14 +83,14 @@
 /area/shuttle/supply)
 "n" = (
 /obj/machinery/door/airlock/shuttle{
-	name = "Supply Shuttle Airlock";
-	req_access_txt = "31"
+	name = "Supply Shuttle Airlock"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/docking_port/mobile/supply{
 	dir = 4;
 	dwidth = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "o" = (
@@ -125,10 +125,10 @@
 /area/shuttle/supply)
 "r" = (
 /obj/machinery/door/airlock/shuttle{
-	name = "Supply Shuttle Airlock";
-	req_access_txt = "31"
+	name = "Supply Shuttle Airlock"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "s" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes errors present within map fucky wuckies
Adds Spaghetti the Atmos Penguin
Gives Engineering a nice little front desk
![image](https://user-images.githubusercontent.com/73589390/185755833-ffb45672-d8ea-4f42-aefe-3a0de8e42ea2.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix good

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: A number of errors related to access were resolved
add: Spaghetti the Atmos Penguin!!!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
