### PR TITLE
Fixes Rimworld Cave Depressurization 

### DIFF
--- a/code/game/turfs/open/planet.dm
+++ b/code/game/turfs/open/planet.dm
@@ -48,7 +48,7 @@
 	name = "jungle grass"
 	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
 	planetary_atmos = TRUE
-	baseturfs = /turf/open/misc/dirt
+	baseturfs = /turf/open/misc/dirt/jungle
 	desc = "Greener on the other side."
 	icon_state = "junglegrass"
 	base_icon_state = "junglegrass"
@@ -58,4 +58,4 @@
 	mineralSpawnChanceList = list(/obj/item/stack/ore/uranium = 5, /obj/item/stack/ore/diamond = 1, /obj/item/stack/ore/gold = 10,
 		/obj/item/stack/ore/silver = 12, /obj/item/stack/ore/plasma = 20, /obj/item/stack/ore/iron = 40, /obj/item/stack/ore/titanium = 11,
 		/obj/item/stack/ore/bluespace_crystal = 1)
-	baseturfs = /turf/open/misc/dirt/dark
+	baseturfs = /turf/open/misc/dirt/dark/jungle


### PR DESCRIPTION

:cl:
fix: Jungle turfs no longer have LAVALAND BASE TURFS and are no longer atmosdiff HELL
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
