### PR TITLE
fixes all requests consoles, adds more, adds intercoms, adds newscasters

### DIFF
--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -21642,7 +21642,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/requests_console/directional/south{
-	department = "Dectective";
+	department = "Detective";
 	departmentType = 4;
 	name = "Detective's Request Console"
 	},

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -3092,6 +3092,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/requests_console/directional/east{
+	department = "Science";
+	departmentType = 3;
+	name = "Science Requests Console"
+	},
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aOp" = (
@@ -5956,10 +5961,14 @@
 "bwz" = (
 /obj/structure/table/wood,
 /obj/machinery/light_switch/directional/east,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/item/toy/figure/curator,
 /obj/machinery/camera/directional/east{
 	c_tag = "Genetics Desk"
+	},
+/obj/machinery/requests_console/directional/south{
+	department = "Library";
+	name = "Library Requests Console";
+	departmentType = 4
 	},
 /turf/open/floor/carpet/red,
 /area/service/library/upper)
@@ -8555,6 +8564,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/red/side{
 	dir = 6
 	},
@@ -9006,7 +9016,6 @@
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor3/port)
 "cnx" = (
-/obj/machinery/requests_console/directional/north,
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
@@ -9692,7 +9701,6 @@
 /turf/open/floor/wood,
 /area/commons/dorms/apartment1)
 "cyf" = (
-/obj/machinery/requests_console/directional/south,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "cyh" = (
@@ -10937,8 +10945,12 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "cSf" = (
-/obj/machinery/requests_console/directional/south,
 /obj/machinery/seed_extractor,
+/obj/machinery/requests_console/directional/south{
+	department = "Hydroponics";
+	departmentType = 2;
+	name = "Hydroponics Requests Console"
+	},
 /turf/open/floor/iron/green,
 /area/service/hydroponics)
 "cSg" = (
@@ -14066,9 +14078,9 @@
 /obj/effect/landmark/start/captain,
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
-	department = "Captain's Office";
-	departmentType = 5;
-	name = "Captain's Request Console"
+	department = "Cargo";
+	departmentType = 7;
+	name = "Cargo Request Console"
 	},
 /turf/open/floor/wood/tile,
 /area/command/heads_quarters/captain/private)
@@ -16475,7 +16487,10 @@
 /turf/open/floor/eighties,
 /area/commons/fitness/recreation/entertainment)
 "eyY" = (
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/directional/north{
+	department = "Tool Storage";
+	name = "Tool Storage Requests Console"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -20406,7 +20421,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/requests_console/directional/east{
-	department = "Bar";
+	department = "Service";
 	departmentType = 2;
 	name = "Service Hall Requests Console"
 	},
@@ -20619,6 +20634,12 @@
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/requests_console/directional/south{
+	announcementConsole = 1;
+	department = "Quartermaster's Desk";
+	name = "Quartermaster's Request Console";
+	departmentType = 7
+	},
 /turf/open/floor/wood/large,
 /area/cargo/qm)
 "fOb" = (
@@ -21620,6 +21641,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/requests_console/directional/south{
+	department = "Dectective";
+	departmentType = 4;
+	name = "Detective's Request Console"
+	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "gcQ" = (
@@ -29178,7 +29204,12 @@
 /obj/machinery/light/directional/west,
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Warden's Desk";
+	departmentType = 7;
+	name = "Warden's Requests Console"
+	},
 /turf/open/floor/iron/dark/red/corner{
 	dir = 4
 	},
@@ -36597,7 +36628,11 @@
 	pixel_y = 5
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/newscaster/directional/north,
+/obj/machinery/requests_console/directional/north{
+	department = "Chapel";
+	name = "Chapel Requests Console";
+	departmentType = 5
+	},
 /turf/open/floor/carpet/orange,
 /area/service/chapel/office)
 "kvB" = (
@@ -37610,6 +37645,11 @@
 "kJp" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/machinery/requests_console/directional/west{
+	department = "Circuit Lab";
+	name = "Circuit Lab Requests Console";
+	departmentType = 3
+	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "kJD" = (
@@ -37730,6 +37770,11 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/requests_console/directional/east{
+	department = "Cargo";
+	departmentType = 3;
+	name = "Cargo Request Console"
+	},
 /turf/open/floor/iron/smooth,
 /area/cargo/office)
 "kKP" = (
@@ -39028,6 +39073,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/machinery/requests_console/directional/east{
+	department = "Conservator Science Wing";
+	name = "Conservators Requests Console"
 	},
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
@@ -42190,6 +42239,7 @@
 "lWl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
 	},
@@ -42258,6 +42308,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "lXw" = (
+/obj/machinery/requests_console/directional/north{
+	department = "AI";
+	name = "AI Requests Console";
+	departmentType = 3
+	},
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
@@ -45845,6 +45900,21 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
+"mVz" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/machinery/computer/scan_consolenew,
+/obj/machinery/light/cold/no_nightlight/directional/north,
+/obj/machinery/requests_console/directional/north{
+	department = "Genetics";
+	name = "Genetics Requests Console";
+	departmentType = 5
+	},
+/turf/open/floor/iron/showroomfloor{
+	name = "lab floor"
+	},
+/area/science/genetics)
 "mVC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47533,6 +47603,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
+"nqj" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/requests_console/directional/north{
+	department = "Mekhane Workshop";
+	departmentType = 5;
+	name = "Mekhane Requests Console";
+	announcementConsole = 1
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/faction/mekhane_workshop)
 "nqm" = (
 /turf/open/floor/iron/dark/side{
 	dir = 5
@@ -49365,6 +49449,12 @@
 /obj/machinery/camera/directional/west{
 	c_tag = null;
 	name = "Telecomms - Control"
+	},
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 7;
+	name = "Telecommunications Requests Console"
 	},
 /turf/open/floor/iron/smooth,
 /area/tcommsat/computer)
@@ -52319,7 +52409,12 @@
 /area/science/genetics)
 "oGo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/machinery/requests_console/directional/south,
+/obj/machinery/requests_console/directional/south{
+	department = "Bridge";
+	departmentType = 7;
+	name = "Bridge Request Console";
+	announcementConsole = 1
+	},
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
 	},
@@ -55258,6 +55353,11 @@
 "pBS" = (
 /obj/structure/table,
 /obj/machinery/light/directional/east,
+/obj/machinery/requests_console/directional/east{
+	department = "Kitchen";
+	departmentType = 2;
+	name = "Kitchen Requests Console"
+	},
 /turf/open/floor/iron/kitchen,
 /area/service/kitchen)
 "pBV" = (
@@ -56507,6 +56607,12 @@
 /obj/machinery/recharger,
 /obj/machinery/newscaster/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/requests_console/directional/north{
+	department = "Home Guard";
+	departmentType = 5;
+	name = "Home Guard Requests Console";
+	announcementConsole = 1
+	},
 /turf/open/floor/iron/dark/green/side{
 	dir = 5
 	},
@@ -56982,6 +57088,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/requests_console/directional/east{
+	department = "Salvage Bay";
+	departmentType = 5;
+	name = "Salvage Bay Request Console"
+	},
 /turf/open/floor/catwalk_floor/iron,
 /area/cargo/miningdock)
 "qcX" = (
@@ -57344,7 +57455,11 @@
 /turf/open/floor/grass,
 /area/hallway/floor2/fore)
 "qii" = (
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/directional/north{
+	department = "Psychology";
+	departmentType = 4;
+	name = "Psych's Requests Console"
+	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "qik" = (
@@ -59467,7 +59582,8 @@
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
 	department = "Captain's Desk";
-	departmentType = 5
+	departmentType = 5;
+	name = "Captain's Requests Console"
 	},
 /turf/open/floor/wood/tile,
 /area/command/heads_quarters/captain/private)
@@ -59717,6 +59833,12 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/wood,
+/obj/machinery/requests_console/directional/south{
+	department = "Conservators";
+	announcementConsole = 1;
+	departmentType = 5;
+	name = "Conservators Requests Console"
+	},
 /turf/open/floor/carpet/green,
 /area/faction/conserve_recycling)
 "qPl" = (
@@ -61883,6 +62005,11 @@
 	dir = 5
 	},
 /obj/structure/noticeboard/directional/north,
+/obj/machinery/requests_console/directional/east{
+	department = "Xenobiology";
+	departmentType = 3;
+	name = "Xenobiology Requests Console"
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "rwV" = (
@@ -62745,7 +62872,6 @@
 /turf/open/floor/iron/dark,
 /area/hallway/floor1/fore)
 "rKz" = (
-/obj/structure/sign/poster/random/directional/north,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/wood,
 /area/service/theater/abandoned)
@@ -63559,6 +63685,11 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/machinery/requests_console/directional/south{
+	department = "Medbay";
+	departmentType = 7;
+	name = "Medbay Requests Console"
 	},
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
@@ -65216,6 +65347,7 @@
 	},
 /obj/machinery/computer/scan_consolenew,
 /obj/machinery/light/cold/no_nightlight/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/showroomfloor{
 	name = "lab floor"
 	},
@@ -66381,6 +66513,11 @@
 "sQi" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/requests_console/directional/south{
+	department = "Medbay";
+	departmentType = 7;
+	name = "Medbay Requests Console"
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "sQj" = (
@@ -67040,6 +67177,11 @@
 "sZb" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
+/obj/machinery/requests_console/directional/north{
+	department = "Engineering";
+	departmentType = 7;
+	name = "Engineering Requests Console"
+	},
 /turf/open/floor/iron/corner{
 	dir = 8
 	},
@@ -67315,7 +67457,6 @@
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 4
 	},
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/showroomfloor{
 	name = "lab floor"
 	},
@@ -68088,6 +68229,11 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/directional/west,
+/obj/machinery/requests_console/directional/west{
+	department = "Medbay";
+	departmentType = 7;
+	name = "Medbay Requests Console"
+	},
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "toy" = (
@@ -68171,6 +68317,11 @@
 	pixel_x = -6
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/requests_console/directional/north{
+	departmentType = 2;
+	department = "Bar";
+	name = "Bar Requests Console"
+	},
 /turf/open/floor/iron/green,
 /area/service/bar)
 "tpU" = (
@@ -69065,6 +69216,10 @@
 "tEK" = (
 /obj/structure/table/wood,
 /obj/machinery/camera/directional/west,
+/obj/machinery/requests_console/directional/west{
+	department = "Quarantine";
+	name = "Quarantine Requests Console"
+	},
 /turf/open/floor/wood/parquet,
 /area/medical/virology)
 "tEL" = (
@@ -69450,7 +69605,6 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/obj/machinery/requests_console/directional/north,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/commons/dorms)
@@ -71269,6 +71423,12 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Chiron Biolabs";
+	departmentType = 5;
+	name = "Chiron Biolabs Requests Console"
+	},
 /turf/open/floor/iron/dark/blue/side{
 	dir = 4
 	},
@@ -73504,6 +73664,12 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/requests_console/directional/south{
+	department = "Unity";
+	announcementConsole = 1;
+	departmentType = 5;
+	name = "Unity Requests Console"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -74189,6 +74355,11 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/requests_console/directional/south{
+	department = "Chief Engineer's Desk";
+	departmentType = 7;
+	name = "Chief Engineer's Requests Console"
+	},
 /turf/open/floor/iron/dark/yellow/side,
 /area/command/heads_quarters/ce)
 "vgo" = (
@@ -74731,6 +74902,7 @@
 	pixel_y = 10
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white/textured_large,
 /area/service/chapel/office)
 "vom" = (
@@ -76230,7 +76402,8 @@
 "vJS" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Law Office";
-	name = "Lawyer Requests Console"
+	name = "Lawyer Requests Console";
+	departmentType = 4
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
@@ -76505,6 +76678,11 @@
 	pixel_x = 6;
 	pixel_y = -3
 	},
+/obj/machinery/requests_console/directional/west{
+	department = "Robotics";
+	departmentType = 5;
+	name = "Robotics Requests Console"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/science/robotics/lab)
 "vOo" = (
@@ -76735,7 +76913,8 @@
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
 	department = "Captain's Desk";
-	departmentType = 5
+	departmentType = 5;
+	name = "Captain's Requests Console"
 	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
@@ -78877,6 +79056,10 @@
 /obj/item/megaphone/clown,
 /obj/item/pneumatic_cannon/pie,
 /obj/item/reagent_containers/food/drinks/soda_cans/canned_laughter,
+/obj/machinery/requests_console/directional/south{
+	department = "Theatre";
+	name = "Theatre Requests Console"
+	},
 /turf/open/floor/carpet/red,
 /area/service/theater)
 "wwi" = (
@@ -81535,6 +81718,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/requests_console/directional/south{
+	department = "Cryogenic Storage";
+	departmentType = 1;
+	name = "Cryogenics Requests Console"
+	},
 /turf/open/floor/iron/dark/side,
 /area/commons/cryo_storage)
 "xhB" = (
@@ -82479,7 +82667,11 @@
 /obj/item/clothing/glasses/science,
 /obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/directional/north{
+	department = "Virology";
+	departmentType = 1;
+	name = "Virology Requests Console"
+	},
 /obj/machinery/light/cold/no_nightlight/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
@@ -183511,7 +183703,7 @@ tOQ
 uSr
 kIV
 xaQ
-syC
+mVz
 azJ
 thj
 aER
@@ -260618,7 +260810,7 @@ kRw
 gqF
 qKG
 aKx
-lEC
+nqj
 lEC
 oQy
 nhf

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -1968,6 +1968,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/blue,
 /area/medical/morgue)
 "azu" = (
@@ -3095,6 +3096,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -3820,6 +3822,7 @@
 /obj/machinery/camera/autoname/directional/west{
 	dir = 9
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1
 	},
@@ -3829,9 +3832,9 @@
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "aXY" = (
-/obj/machinery/firealarm/directional/west,
 /obj/structure/table,
 /obj/item/aicard,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aYd" = (
@@ -4295,6 +4298,12 @@
 /obj/effect/spawner/random/engineering/material_cheap,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port/fore)
+"bdR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/blue,
+/area/faction/chiron_hq)
 "bel" = (
 /obj/structure/rack/shelf,
 /turf/open/floor/pod/light,
@@ -6301,6 +6310,7 @@
 	dir = 1;
 	piping_layer = 2
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/storage/gas)
 "bAv" = (
@@ -7348,6 +7358,7 @@
 /area/maintenance/solars/starboard/fore)
 "bQz" = (
 /obj/machinery/camera/autoname/directional/north,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "bQG" = (
@@ -10387,6 +10398,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/faction/unity)
 "cKs" = (
@@ -10663,6 +10675,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/lobby)
 "cPe" = (
@@ -10967,6 +10980,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/hallway/floor2/fore)
 "cSY" = (
@@ -11369,6 +11383,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/atmospherics_engine)
 "cXO" = (
@@ -11433,6 +11448,14 @@
 	dir = 8
 	},
 /area/faction/unity)
+"cYF" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/storage/gas)
 "cYR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -13706,6 +13729,7 @@
 	req_access = list("mail_sorting")
 	},
 /obj/effect/spawner/random/maintenance/four,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "dJf" = (
@@ -14344,8 +14368,18 @@
 /area/command/bridge)
 "dSe" = (
 /obj/effect/spawner/random/vending/colavend,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/hallway/floor1/fore)
+"dSf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/wood,
+/area/service/dining)
 "dSl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/blue/side{
@@ -16498,6 +16532,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/toilet/restrooms)
+"eAm" = (
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "eAr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16576,6 +16615,7 @@
 "eBT" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/suit_storage_unit/ce,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/ce)
 "eCf" = (
@@ -16715,6 +16755,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/floor1/aft)
+"eEr" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/wood,
+/area/service/dining)
 "eEu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -17079,6 +17123,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/darkpurple/line,
 /obj/structure/cable,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "eJO" = (
@@ -17215,6 +17260,9 @@
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/east{
+	dir = 5
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/lobby)
 "eMg" = (
@@ -17619,6 +17667,10 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/wood,
 /area/service/theater)
+"eUj" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/engine,
+/area/engineering/supermatter)
 "eUn" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/red/side{
@@ -17835,6 +17887,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "eXV" = (
@@ -19057,6 +19110,7 @@
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/science/cytology)
 "frE" = (
@@ -20132,11 +20186,9 @@
 /turf/open/floor/pod/dark,
 /area/maintenance/floor3/starboard)
 "fIa" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/blue/side{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/carpet/royalblack,
+/area/service/dining)
 "fIg" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/pod/light,
@@ -20281,6 +20333,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
 "fKr" = (
@@ -20561,6 +20614,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
 "fOu" = (
@@ -21898,6 +21952,7 @@
 /area/commons/locker)
 "gip" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/carpet/royalblack,
 /area/service/dining)
 "gir" = (
@@ -21987,6 +22042,8 @@
 /turf/open/floor/iron/dark/red/side,
 /area/maintenance/floor2/starboard/aft)
 "gkD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 4
 	},
@@ -22484,6 +22541,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/blue,
 /area/medical/psychology)
+"gss" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side,
+/area/faction/chiron_hq)
 "gst" = (
 /obj/structure/chair{
 	dir = 4
@@ -23930,6 +23992,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
 "gPR" = (
@@ -25698,6 +25761,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/faction/mekhane_workshop)
 "hpK" = (
@@ -25776,6 +25840,7 @@
 /obj/structure/chair/plastic{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/hallway/floor2/aft)
 "hry" = (
@@ -28773,6 +28838,12 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west{
+	name = "Private Channel";
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ikg" = (
@@ -28792,6 +28863,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/carpet/royalblack,
 /area/service/dining)
 "iko" = (
@@ -31974,6 +32046,12 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor3/aft)
+"jiM" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark/red/side{
+	dir = 8
+	},
+/area/security/prison)
 "jjo" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white/textured_large,
@@ -32244,7 +32322,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/firealarm/directional/east,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/floor3/fore)
 "jnF" = (
@@ -36593,6 +36671,7 @@
 /obj/machinery/camera/directional/south{
 	c_tag = "Science - Cytology Lower"
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/science/cytology/lower)
 "kxK" = (
@@ -36877,6 +36956,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/start/station_engineer,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/lobby)
 "kBL" = (
@@ -37185,6 +37265,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/service/library/printer)
 "kGy" = (
@@ -37383,6 +37464,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"kII" = (
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/wood,
+/area/service/dining)
 "kIO" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/security_officer,
@@ -37723,6 +37808,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
 "kNd" = (
@@ -38701,7 +38787,6 @@
 /turf/open/openspace,
 /area/maintenance/floor2/starboard)
 "lcr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/paper/fluff{
@@ -39541,6 +39626,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lnU" = (
@@ -39772,11 +39858,10 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/aft)
 "lqz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
 "lqD" = (
@@ -39917,6 +40002,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/hallway/floor2/aft)
 "lsT" = (
@@ -41093,6 +41179,12 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/wood,
 /area/medical/psychology/ward)
+"lJS" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end,
+/obj/machinery/light/small/directional/south,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/hallway/floor2/fore)
 "lJZ" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/line{
@@ -41797,6 +41889,12 @@
 /turf/open/floor/plating,
 /area/science/server)
 "lSE" = (
+/obj/item/radio/intercom/directional/north{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
 /turf/open/floor/iron/dark/blue/side{
 	dir = 9
 	},
@@ -43298,6 +43396,11 @@
 /obj/item/food/grown/coffee,
 /turf/open/floor/pod/light,
 /area/maintenance/floor3/starboard)
+"mof" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/wood,
+/area/service/dining)
 "mog" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43553,6 +43656,7 @@
 /obj/effect/turf_decal/trimline/white/mid_joiner{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/commons/cryo_storage)
 "mrU" = (
@@ -44030,7 +44134,6 @@
 	pixel_x = 8;
 	pixel_y = 12
 	},
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood/large,
 /area/cargo/qm)
 "myr" = (
@@ -44799,6 +44902,7 @@
 /obj/structure/chair/sofa/corner{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/carpet/royalblack,
 /area/service/dining)
 "mKj" = (
@@ -44885,6 +44989,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
@@ -46647,6 +46752,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/floor3/fore)
+"niD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/medical/psychology/ward)
 "niE" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
@@ -47541,6 +47652,7 @@
 "nsO" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/maintenance/disposal)
 "nsX" = (
@@ -48055,9 +48167,9 @@
 /turf/open/floor/iron/dark/brown/side,
 /area/commons/dorms/room3)
 "nAH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/chair/sofa/bench/left,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
 "nAJ" = (
@@ -48362,6 +48474,7 @@
 /area/hallway/floor3/aft)
 "nEZ" = (
 /obj/machinery/vending/security,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/red,
 /area/security/lockers)
 "nFa" = (
@@ -48820,6 +48933,7 @@
 "nLd" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album/library,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet/red,
 /area/service/library/upper)
 "nLk" = (
@@ -48992,6 +49106,8 @@
 	name = "Chiron Gene Therapy Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/faction/chiron_biolabs,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
 "nNT" = (
@@ -49030,6 +49146,12 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/north,
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "Private Channel"
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "nOH" = (
@@ -49124,6 +49246,7 @@
 /obj/machinery/light/directional/south,
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_casing/spent,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "nPE" = (
@@ -49206,6 +49329,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/floor3/fore)
 "nQO" = (
@@ -50842,6 +50966,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor3/starboard/aft)
+"ont" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "onw" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Abandoned Den"
@@ -50888,6 +51016,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/east,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/textured_large,
 /area/cargo/qm)
 "ool" = (
@@ -51125,6 +51254,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "oqT" = (
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/green,
 /area/service/hydroponics)
 "oqW" = (
@@ -51751,6 +51881,7 @@
 /area/service/library/garden)
 "oAN" = (
 /obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -51793,6 +51924,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/stripes,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating,
 /area/science)
 "oBB" = (
@@ -52289,6 +52421,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/catwalk_floor/iron_white,
 /area/cargo/miningdock)
 "oIU" = (
@@ -53441,9 +53574,9 @@
 /turf/open/floor/iron/white,
 /area/science/lower)
 "pcf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/chair/sofa/bench/right,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
 "pcg" = (
@@ -54084,6 +54217,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmospherics_engine)
 "poe" = (
@@ -54467,6 +54601,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/hallway/floor1/fore)
+"ptg" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/hallway/floor4/aft)
 "ptu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54628,6 +54768,7 @@
 	dir = 4
 	},
 /obj/machinery/hydroponics/constructable,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "pwH" = (
@@ -54708,6 +54849,7 @@
 /turf/open/floor/engine,
 /area/science/cytology/lower)
 "pxC" = (
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -55302,6 +55444,7 @@
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/engineering/lobby)
 "pGG" = (
@@ -56362,6 +56505,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/faction/chiron_hq)
 "pYd" = (
@@ -56518,6 +56662,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/royalblack,
 /area/service/dining)
 "pZB" = (
@@ -57148,6 +57293,10 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/openspace,
 /area/hallway/floor3/aft)
+"qkc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side,
+/area/faction/chiron_hq)
 "qki" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/telecomms,
@@ -58448,6 +58597,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/north,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "qCa" = (
@@ -61490,6 +61640,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "ruT" = (
@@ -61816,6 +61967,7 @@
 /area/command/meeting_room)
 "rAu" = (
 /obj/machinery/medical_kiosk,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/blue,
 /area/faction/chiron_hq)
 "rAv" = (
@@ -62287,6 +62439,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/floor3/aft)
+"rIl" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1423;
+	listening = 0;
+	name = "Interrogation Intercom"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "rIo" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/floor4/starboard/aft)
@@ -63910,6 +64072,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/kitchen/diner)
+"skj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "skv" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64190,6 +64359,8 @@
 /obj/structure/sign/warning/chemdiamond{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 8
 	},
@@ -64430,6 +64601,7 @@
 /obj/structure/chair/sofa/corner{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet/royalblack,
 /area/service/dining)
 "ssk" = (
@@ -64588,6 +64760,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/floor1/port/aft)
+"sus" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "sut" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/grime,
@@ -64615,6 +64792,7 @@
 /area/maintenance/floor1/port/fore)
 "suV" = (
 /obj/structure/bed/roller,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/blue,
 /area/faction/chiron_hq)
 "suX" = (
@@ -64722,6 +64900,15 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/hallway/floor2/fore)
+"sws" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "swv" = (
 /obj/structure/shuttle/engine/large/in_wall{
 	dir = 4
@@ -65972,6 +66159,7 @@
 /area/maintenance/floor3/port/aft)
 "sOG" = (
 /obj/machinery/light/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -67225,6 +67413,7 @@
 /obj/machinery/camera/autoname/directional/south{
 	dir = 6
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "tgA" = (
@@ -68051,6 +68240,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/red,
 /area/security/prison)
+"ttt" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "ttC" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -68248,6 +68444,7 @@
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/starboard/fore)
 "twO" = (
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/blue/side,
 /area/ai_monitored/turret_protected/aisat_interior)
 "twQ" = (
@@ -68395,6 +68592,7 @@
 /obj/machinery/camera/autoname/directional/south{
 	dir = 6
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/yellow/side{
 	dir = 8
 	},
@@ -68454,6 +68652,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/airalarm/directional/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/blue/corner{
 	dir = 1
 	},
@@ -68968,6 +69167,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
@@ -69890,6 +70090,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "tXR" = (
@@ -70731,6 +70932,9 @@
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
 "ujV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/blue,
 /area/faction/chiron_hq)
 "ukd" = (
@@ -70947,6 +71151,15 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"unZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/blue/side{
+	dir = 1
+	},
+/area/faction/chiron_hq)
 "uon" = (
 /obj/item/radio/intercom/directional/north,
 /obj/structure/disposalpipe/segment{
@@ -71844,6 +72057,7 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
 "uEz" = (
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 5
 	},
@@ -72336,6 +72550,7 @@
 	},
 /obj/machinery/light/small/red/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood/large,
 /area/cargo/qm)
 "uKR" = (
@@ -74079,6 +74294,7 @@
 "vkZ" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/gun/energy/laser,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/warden)
 "vlb" = (
@@ -74932,6 +75148,7 @@
 /area/hallway/floor2/aft)
 "vvY" = (
 /obj/item/kirbyplants/random,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
@@ -75029,6 +75246,7 @@
 /obj/item/storage/medkit/regular,
 /obj/item/reagent_containers/glass/bottle/multiver,
 /obj/item/reagent_containers/syringe,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/security/medical)
 "vxN" = (
@@ -76315,6 +76533,7 @@
 "vQB" = (
 /obj/machinery/light/directional/west,
 /obj/structure/cable,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/service/dining)
 "vQD" = (
@@ -79224,6 +79443,7 @@
 /obj/machinery/computer/crew{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "wFV" = (
@@ -79739,6 +79959,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms/room3)
+"wMw" = (
+/obj/structure/dresser,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/wood,
+/area/cargo/miningdock)
 "wMy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -80659,6 +80884,7 @@
 /obj/effect/turf_decal/trimline/white/mid_joiner{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/smooth_large,
 /area/commons/cryo_storage)
 "xat" = (
@@ -81842,6 +82068,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/floor2/fore)
 "xsH" = (
@@ -82668,6 +82895,7 @@
 	},
 /area/faction/homeguard)
 "xEw" = (
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/blue/corner,
 /area/faction/chiron_hq)
 "xEB" = (
@@ -83725,6 +83953,7 @@
 /obj/structure/table,
 /obj/item/toy/cards/deck,
 /obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark/red/side,
 /area/security/brig)
 "xVV" = (
@@ -112420,7 +112649,7 @@ fOb
 wSg
 kTS
 ifJ
-ifJ
+ont
 jxU
 eaa
 aRt
@@ -114260,7 +114489,7 @@ wnN
 ybs
 pXb
 jIs
-eIZ
+niD
 vyn
 ybs
 ybs
@@ -115506,7 +115735,7 @@ tKU
 fXU
 tXJ
 aRt
-has
+wMw
 kLn
 aRt
 llR
@@ -123206,7 +123435,7 @@ owI
 yhJ
 dYr
 nkx
-nkx
+eAm
 mZE
 vgx
 mZE
@@ -125304,8 +125533,8 @@ pLQ
 gkD
 pcf
 snn
-rpy
-ujV
+qkc
+bdR
 suV
 xgH
 hdA
@@ -125558,10 +125787,10 @@ xgH
 uTu
 tdD
 osX
-aaN
+unZ
 nAH
 snn
-rpy
+gss
 ujV
 rAu
 xgH
@@ -126557,7 +126786,7 @@ kZg
 cDv
 gfW
 gmw
-isd
+sws
 wfT
 wfT
 kbu
@@ -131954,7 +132183,7 @@ oPM
 hWP
 rit
 rit
-nXP
+skj
 kFk
 akS
 iHa
@@ -132486,7 +132715,7 @@ xjs
 lPX
 ajg
 gIs
-hjR
+eUj
 pEq
 wiF
 jHS
@@ -132988,7 +133217,7 @@ fJw
 tEU
 qyN
 mPE
-fKL
+cYF
 akS
 gbw
 cVm
@@ -172071,7 +172300,7 @@ dhX
 shi
 fci
 fWh
-gAp
+lJS
 hLz
 uXA
 lft
@@ -195965,7 +196194,7 @@ hgq
 hgq
 ffv
 oia
-wBq
+sus
 tPm
 gSu
 tPm
@@ -196479,7 +196708,7 @@ wBq
 qVp
 aVq
 bMG
-wBq
+rIl
 tPm
 gSu
 tPm
@@ -237871,7 +238100,7 @@ ddx
 rBC
 lAx
 jYz
-pSz
+fIa
 gwL
 gwL
 gwL
@@ -239158,7 +239387,7 @@ xna
 xna
 mtF
 fvp
-xna
+dSf
 xna
 mtF
 bkz
@@ -239933,7 +240162,7 @@ efv
 hgC
 sIA
 nyw
-vXx
+kII
 gwL
 aZw
 sIx
@@ -240434,8 +240663,8 @@ tzH
 tmq
 tmq
 iwU
-hdo
-vXx
+mof
+eEr
 vXx
 nNJ
 ycW
@@ -249161,7 +249390,7 @@ opC
 lEz
 dNN
 dNN
-cdF
+xak
 sbq
 xFD
 oPG
@@ -249943,7 +250172,7 @@ ofa
 hYE
 nXk
 hYE
-hYE
+ttt
 aap
 hYE
 tLr
@@ -311618,7 +311847,7 @@ uVr
 dYh
 xos
 uIk
-bVy
+ptg
 jWk
 xAt
 erp
@@ -316257,7 +316486,7 @@ pJV
 imy
 ygI
 guF
-xHs
+jiM
 gsz
 xHs
 imy
@@ -327295,7 +327524,7 @@ ium
 rPb
 twO
 sZN
-fIa
+dJY
 ygu
 vXU
 qgY

--- a/_maps/map_files/NorthPoint/north_point2.dmm
+++ b/_maps/map_files/NorthPoint/north_point2.dmm
@@ -926,6 +926,8 @@
 "amg" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/camera/autoname/directional/south,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
@@ -3341,6 +3343,7 @@
 "aRI" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark/green/side{
 	dir = 6
 	},
@@ -3399,6 +3402,7 @@
 "aSq" = (
 /obj/machinery/rnd/production/protolathe/department/science,
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "aSu" = (
@@ -3909,6 +3913,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/science/robotics/mechbay)
 "aYQ" = (
@@ -5349,6 +5354,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
 "bqb" = (
@@ -5882,6 +5888,15 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/kitchen,
 /area/service/bar)
+"bvO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "bvP" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -9357,6 +9372,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "csY" = (
@@ -9721,6 +9737,7 @@
 "cyL" = (
 /obj/structure/table/wood,
 /obj/item/storage/dice,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood/large,
 /area/service/library/lounge)
 "cyT" = (
@@ -10071,6 +10088,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Genetics Desk"
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/science/genetics)
 "cFK" = (
@@ -10372,6 +10390,7 @@
 /area/hallway/floor2/aft)
 "cJJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "cJY" = (
@@ -10424,6 +10443,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "cKE" = (
@@ -10840,6 +10860,7 @@
 /area/science/lower)
 "cRe" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "cRk" = (
@@ -11679,6 +11700,14 @@
 	},
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"ddb" = (
+/obj/structure/closet/crate/solarpanel_small,
+/obj/machinery/door/window/left/directional/west{
+	name = "Spare Solars";
+	req_access = list("external")
+	},
+/turf/open/floor/plating/airless,
+/area/maintenance/solars/starboard/aft)
 "ddd" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -12706,6 +12735,7 @@
 /obj/effect/turf_decal/trimline/green/arrow_cw{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "dtv" = (
@@ -13185,6 +13215,7 @@
 /area/faction/survey_wings)
 "dBc" = (
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
@@ -15071,6 +15102,7 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "edX" = (
@@ -15285,6 +15317,7 @@
 	dir = 4
 	},
 /obj/item/kirbyplants/random,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/aft)
 "ehk" = (
@@ -15420,6 +15453,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/service/chapel)
 "ejd" = (
@@ -18092,6 +18126,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/machinery/light/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
 "faA" = (
@@ -18181,9 +18216,13 @@
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
 "fbD" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable,
-/turf/open/floor/carpet,
-/area/command/heads_quarters/captain)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "fcc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19011,6 +19050,7 @@
 "fpk" = (
 /obj/structure/filingcabinet,
 /obj/structure/filingcabinet,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/service/library/printer)
 "fps" = (
@@ -19485,6 +19525,7 @@
 	pixel_y = 4
 	},
 /obj/item/storage/fancy/donut_box,
+/obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "fyb" = (
@@ -19540,6 +19581,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch/directional/north,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "fyY" = (
@@ -19753,6 +19795,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet/green,
 /area/faction/conserve_recycling)
 "fBK" = (
@@ -19907,6 +19950,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
 "fDO" = (
@@ -20568,16 +20612,13 @@
 /turf/closed/wall,
 /area/hallway/floor2/fore)
 "fNW" = (
-/obj/machinery/button/ec_glass{
-	id = "qmwindow";
-	pixel_x = -24
-	},
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood/large,
 /area/cargo/qm)
 "fOb" = (
@@ -20749,6 +20790,7 @@
 /obj/structure/table/wood,
 /obj/item/paper/fluff/ids_for_dummies,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop/private)
 "fQI" = (
@@ -20958,6 +21000,7 @@
 	pixel_y = -4
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/showroomfloor{
 	name = "lab floor"
 	},
@@ -21100,6 +21143,7 @@
 /area/medical/medbay/lobby)
 "fVT" = (
 /obj/machinery/computer/security,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/red,
 /area/security/checkpoint/second)
 "fWa" = (
@@ -21480,6 +21524,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/green/side{
 	dir = 6
 	},
@@ -21840,6 +21885,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
 "ggX" = (
@@ -22028,6 +22074,7 @@
 "gkp" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/computer/apc_control,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/command/heads_quarters/ce)
 "gkq" = (
@@ -22163,6 +22210,7 @@
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/green,
 /area/faction/homeguard)
 "gmg" = (
@@ -22704,6 +22752,7 @@
 /area/science/cytology)
 "guF" = (
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/red/side{
 	dir = 8
 	},
@@ -22875,6 +22924,7 @@
 "gxT" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tcomms)
 "gxW" = (
@@ -23046,6 +23096,7 @@
 "gAp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/hallway/floor2/fore)
 "gAt" = (
@@ -23907,6 +23958,7 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Genetics Desk"
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/kitchen,
 /area/service/kitchen)
 "gPb" = (
@@ -23992,7 +24044,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
 "gPR" = (
@@ -24323,6 +24374,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "gUs" = (
@@ -25126,8 +25178,8 @@
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "hgM" = (
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/libraryscanner,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/red,
 /area/service/library/upper)
 "hgN" = (
@@ -26968,6 +27020,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
 "hJg" = (
@@ -27532,6 +27585,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"hQX" = (
+/obj/structure/table/wood,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/wood,
+/area/hallway/floor3/fore)
 "hRb" = (
 /turf/open/floor/engine,
 /area/science)
@@ -27812,6 +27870,7 @@
 /obj/structure/table,
 /obj/item/folder/blue,
 /obj/item/pen,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "hUx" = (
@@ -28140,11 +28199,11 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "hYT" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/landmark/start/depsec/supply,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
 "hYU" = (
@@ -28161,6 +28220,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood/large,
 /area/command/heads_quarters/hop)
 "hZs" = (
@@ -29871,6 +29931,7 @@
 "izk" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/cargo/scrapbeacon)
 "izm" = (
@@ -30052,6 +30113,7 @@
 /area/space)
 "iCh" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white/textured_large,
 /area/service/chapel)
 "iCk" = (
@@ -31196,6 +31258,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
@@ -31207,7 +31270,7 @@
 /obj/machinery/modular_computer/console/preset/id{
 	name = "Captain's Computer"
 	},
-/obj/machinery/requests_console/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "iUT" = (
@@ -31292,6 +31355,13 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/hallway/floor1/aft)
+"iWE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/engineering/gravity_generator)
 "iWG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/hangover,
@@ -32549,6 +32619,7 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargodisposals"
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "jqy" = (
@@ -32570,6 +32641,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/first)
 "jqH" = (
@@ -33171,6 +33243,7 @@
 /obj/machinery/camera/autoname/directional/south{
 	dir = 6
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jze" = (
@@ -34444,6 +34517,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/commons/cryo_storage)
 "jQS" = (
@@ -35070,6 +35144,7 @@
 /obj/item/construction/plumbing,
 /obj/structure/table/reinforced,
 /obj/machinery/camera/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/medical/chemistry)
 "kaT" = (
@@ -35718,14 +35793,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
 "kjp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood/tile,
 /area/service/library/upper)
 "kju" = (
@@ -36086,6 +36162,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood/large,
 /area/command/heads_quarters/hop)
 "kpR" = (
@@ -36520,6 +36597,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/carpet/orange,
 /area/service/chapel/office)
 "kvB" = (
@@ -37388,6 +37466,7 @@
 	pixel_y = -3
 	},
 /obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/showroomfloor{
 	name = "lab floor"
 	},
@@ -37697,6 +37776,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood,
 /area/cargo/miningdock)
 "kLu" = (
@@ -38511,9 +38591,6 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "kXj" = (
-/obj/machinery/light_switch/directional/south{
-	pixel_x = -12
-	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
@@ -38728,6 +38805,7 @@
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/pod/light,
 /area/maintenance/solars/port/aft)
 "lbK" = (
@@ -39347,6 +39425,7 @@
 /obj/machinery/computer/department_orders/security{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/security/office)
 "lkD" = (
@@ -41324,6 +41403,13 @@
 	},
 /turf/open/floor/engine/airless,
 /area/engineering/atmos/storage/gas)
+"lLU" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/dark,
+/area/faction/conserve_recycling)
 "lLY" = (
 /obj/structure/safe/floor,
 /obj/item/paper/crumpled/bloody{
@@ -41958,6 +42044,7 @@
 /area/science/lower)
 "lTw" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/red/side,
 /area/security/brig)
 "lTA" = (
@@ -44134,6 +44221,10 @@
 	pixel_x = 8;
 	pixel_y = 12
 	},
+/obj/machinery/button/ec_glass{
+	id = "qmwindow";
+	pixel_x = -24
+	},
 /turf/open/floor/wood/large,
 /area/cargo/qm)
 "myr" = (
@@ -45275,6 +45366,7 @@
 /obj/structure/closet/secure_closet/salvagecrew,
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -45557,6 +45649,7 @@
 /obj/machinery/camera/autoname/directional/west{
 	dir = 9
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/chapel{
 	dir = 1
 	},
@@ -46712,9 +46805,12 @@
 /turf/open/misc/asteroid/snow/standard_air,
 /area/maintenance/floor2/port/aft)
 "nih" = (
-/obj/structure/cable,
 /obj/machinery/computer/communications,
-/obj/machinery/power/apc/auto_name/directional/north,
+/obj/item/radio/intercom/directional/north{
+	name = "Captain's Intercom";
+	freerange = 1;
+	listening = 0
+	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "nij" = (
@@ -47652,7 +47748,6 @@
 "nsO" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/maintenance/disposal)
 "nsX" = (
@@ -48934,6 +49029,7 @@
 /obj/structure/table/wood,
 /obj/item/storage/photo_album/library,
 /obj/item/radio/intercom/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/carpet/red,
 /area/service/library/upper)
 "nLk" = (
@@ -49047,6 +49143,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server/upper)
 "nMX" = (
@@ -49529,6 +49626,7 @@
 /area/service/library/printer)
 "nTv" = (
 /obj/machinery/light/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "nTw" = (
@@ -49876,6 +49974,7 @@
 /area/service/chapel)
 "nXX" = (
 /obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/commons/fitness)
 "nYe" = (
@@ -51103,6 +51202,7 @@
 /obj/item/key/security,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/red/side{
 	dir = 5
 	},
@@ -51135,6 +51235,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -51199,6 +51300,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/catwalk_floor/iron,
 /area/cargo/office)
 "oqv" = (
@@ -52157,6 +52259,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/yellow/corner{
 	dir = 8
 	},
@@ -52240,6 +52343,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -53126,6 +53230,7 @@
 	pixel_x = -14;
 	pixel_y = 6
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/red,
 /area/security/office)
 "oTK" = (
@@ -53285,6 +53390,7 @@
 /obj/structure/chair/plastic{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/white,
 /area/hallway/floor2/fore)
 "oXd" = (
@@ -53376,6 +53482,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/commons/dorms/apartment1)
+"oYL" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/command/heads_quarters/captain)
 "oYT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53893,6 +54004,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "pjp" = (
@@ -54745,6 +54857,7 @@
 	id = "disposals"
 	},
 /obj/effect/turf_decal/stripes,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/maintenance/disposal)
 "pwA" = (
@@ -54874,6 +54987,7 @@
 "pxK" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/pod/light,
 /area/maintenance/solars/port/aft)
 "pxQ" = (
@@ -56499,6 +56613,7 @@
 /obj/structure/chair/plastic{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/hallway/floor2/fore)
 "pXU" = (
@@ -56646,7 +56761,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -57377,6 +57492,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/hallway/floor2/aft)
 "qlt" = (
@@ -57432,6 +57548,7 @@
 "qmf" = (
 /obj/machinery/vending/security,
 /obj/machinery/light/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/red,
 /area/security/lockers)
 "qmh" = (
@@ -57489,6 +57606,7 @@
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
 "qnb" = (
@@ -58528,7 +58646,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/carpet,
 /area/cargo/miningdock)
 "qBm" = (
@@ -58977,6 +59094,7 @@
 "qGp" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/medical/psychology/ward)
 "qGC" = (
@@ -59135,6 +59253,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor,
 /area/maintenance/floor1/port/fore)
+"qIS" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/wood,
+/area/hallway/floor3/fore)
 "qIT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59924,6 +60047,11 @@
 	dir = 8
 	},
 /area/hallway/floor3/fore)
+"qTF" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/hallway/floor1/aft)
 "qTH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -60248,6 +60376,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
@@ -60977,6 +61106,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/faction/conserve_recycling)
 "rjf" = (
@@ -61221,6 +61351,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/dining)
+"rnP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/hallway/floor2/aft)
 "rnW" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62443,9 +62580,9 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/item/radio/intercom/directional/south{
 	broadcasting = 1;
-	frequency = 1423;
+	frequency = 1447;
 	listening = 0;
-	name = "Interrogation Intercom"
+	name = "Private Channel"
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -62464,6 +62601,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/commons/cryo_storage)
 "rIt" = (
@@ -64373,6 +64511,7 @@
 /obj/item/toy/plush/slimeplushie{
 	name = "stress toy"
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/psychology/ward)
 "soN" = (
@@ -64401,6 +64540,7 @@
 /obj/machinery/camera/autoname/directional/south{
 	dir = 6
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
@@ -64609,6 +64749,7 @@
 /obj/effect/turf_decal/siding/white,
 /obj/item/folder/white,
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "ssm" = (
@@ -67174,6 +67315,7 @@
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 4
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/showroomfloor{
 	name = "lab floor"
 	},
@@ -68255,6 +68397,12 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating/foam,
 /area/maintenance/floor1/port/aft)
+"ttF" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/wood,
+/area/medical/psychology/ward)
 "ttG" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -68414,6 +68562,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/camera/autoname/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/green/side,
 /area/faction/conserve_recycling)
 "twq" = (
@@ -68780,7 +68929,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/floor1/aft)
 "tCJ" = (
@@ -69287,13 +69435,13 @@
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/maintenance/club)
 "tJX" = (
-/obj/machinery/light_switch/directional/west,
 /obj/structure/table,
 /obj/item/paper/crumpled/fluff{
 	info = "While we are able to make citizen's arrests, <br> I don't want to see anyone repeating what Dave did last Thursday by arresting the person about to pick out the last donut from the cafe.<br> I get it Dave, but we can't abuse our responsibilities like that.";
 	name = "Home Guard Memo"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/green/side{
 	dir = 10
 	},
@@ -70181,6 +70329,7 @@
 "tZq" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/stripes,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/maintenance/disposal)
 "tZz" = (
@@ -70551,6 +70700,12 @@
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/pod/dark,
 /area/maintenance/floor1/port/aft)
+"ueW" = (
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark/red/side{
+	dir = 10
+	},
+/area/security/brig)
 "ueX" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 4
@@ -70720,6 +70875,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/service/chapel/office)
+"uht" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/medical/chemistry)
 "uhu" = (
 /obj/effect/turf_decal/trimline/green/warning,
 /obj/effect/spawner/random/structure/table,
@@ -70929,6 +71088,7 @@
 "ujT" = (
 /obj/item/cigbutt/cigarbutt,
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
 "ujV" = (
@@ -71004,6 +71164,12 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/pod/light,
 /area/maintenance/floor1/port)
+"ulu" = (
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/chapel{
+	dir = 8
+	},
+/area/service/chapel)
 "ulB" = (
 /obj/structure/hedge,
 /turf/open/floor/carpet/green,
@@ -72831,6 +72997,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "uOS" = (
@@ -73187,6 +73354,7 @@
 /obj/structure/chair/sofa/bench{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/hallway/floor2/fore)
 "uUA" = (
@@ -73518,6 +73686,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/service/chapel)
 "uYB" = (
@@ -74691,6 +74860,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -75257,6 +75427,7 @@
 /area/maintenance/floor1/port)
 "vxU" = (
 /obj/effect/turf_decal/stripes/corner,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "vyn" = (
@@ -76000,6 +76171,7 @@
 /area/hallway/floor4/fore)
 "vIX" = (
 /obj/structure/disposalpipe/segment,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/hallway/floor2/aft)
 "vIZ" = (
@@ -76225,6 +76397,7 @@
 /area/cargo/sorting)
 "vMX" = (
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark/blue/side{
 	dir = 1
 	},
@@ -76559,8 +76732,11 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "vRi" = (
-/obj/structure/cable,
-/obj/item/radio/intercom/directional/east,
+/obj/machinery/requests_console/directional/east{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5
+	},
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "vRj" = (
@@ -80584,6 +80760,7 @@
 /obj/structure/rack,
 /obj/item/wrench,
 /obj/item/wirecutters,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/pod/light,
 /area/maintenance/solars/starboard/aft)
 "wVz" = (
@@ -80787,6 +80964,7 @@
 "wYR" = (
 /obj/machinery/holopad/secure,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain)
 "wYW" = (
@@ -80857,6 +81035,7 @@
 /obj/effect/landmark/start/quartermaster,
 /obj/machinery/light/small/red/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/cargo/qm)
 "xad" = (
@@ -82706,6 +82885,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/cargo/miningdock)
 "xBX" = (
@@ -84481,6 +84661,7 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/blue,
 /area/medical/morgue)
 "ycW" = (
@@ -102625,7 +102806,7 @@ pzU
 mUe
 oic
 fSw
-nKQ
+lLU
 buU
 tyd
 mQk
@@ -115512,7 +115693,7 @@ xgH
 xgH
 wVn
 xgH
-qGp
+ttF
 cIi
 lJN
 ybs
@@ -117789,7 +117970,7 @@ bZN
 bZN
 bZN
 bZN
-wdP
+bvO
 aRt
 cms
 vxH
@@ -119104,7 +119285,7 @@ pfM
 eRe
 cvu
 cvu
-cvu
+uht
 mrW
 cvu
 pfM
@@ -123721,7 +123902,7 @@ iII
 hbk
 ibE
 xCk
-ibE
+qTF
 woP
 tqo
 kCg
@@ -134535,7 +134716,7 @@ wQC
 qjj
 aHH
 ifS
-aHH
+iWE
 dEc
 dEc
 vYD
@@ -182833,7 +183014,7 @@ bus
 bus
 cys
 cys
-noh
+fbD
 qSn
 qSn
 hmk
@@ -194652,7 +194833,7 @@ qBW
 guc
 reC
 kzK
-qYb
+rnP
 wyt
 aWR
 aZn
@@ -234493,7 +234674,7 @@ oon
 oon
 sKN
 wFY
-kkr
+qIS
 gwL
 fmF
 oQS
@@ -234750,7 +234931,7 @@ wdb
 huJ
 hQA
 mlX
-kkr
+hQX
 gwL
 fmF
 oQS
@@ -242724,7 +242905,7 @@ pUs
 vhd
 pUs
 pUs
-rgm
+pUs
 pUs
 pUs
 pZr
@@ -258365,7 +258546,7 @@ izw
 cIM
 kRw
 ovL
-sLa
+kjp
 kgK
 mAJ
 fll
@@ -258880,7 +259061,7 @@ cIM
 kRw
 jUT
 wJS
-kjp
+blF
 pQk
 jHR
 hjg
@@ -261964,7 +262145,7 @@ cIM
 cIM
 tYW
 lKj
-lKj
+ddb
 tYW
 keM
 tYW
@@ -302067,7 +302248,7 @@ xHe
 olV
 lJp
 aNs
-apJ
+oYL
 wYR
 cJJ
 kWx
@@ -303096,7 +303277,7 @@ ruT
 uTG
 buh
 nih
-fbD
+apJ
 vRi
 lRR
 sCG
@@ -318275,7 +318456,7 @@ iqg
 eZM
 dWp
 dWp
-tXU
+ueW
 fgl
 kty
 efz
@@ -319543,7 +319724,7 @@ cff
 wQN
 aZG
 fwV
-kpz
+ulu
 dlW
 lgz
 dlW

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -310,18 +310,20 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/requests_console, 30)
 
 		var/radio_freq
 		switch(ckey(to_department))
-			if("bridge")
+			if("bridge", "command")
 				radio_freq = FREQ_COMMAND
-			if("medbay")
+			if("medbay", "medical")
 				radio_freq = FREQ_MEDICAL
-			if("science")
+			if("science", "circuitlab", "robotics", "genetics", "xenobiology")
 				radio_freq = FREQ_SCIENCE
-			if("engineering")
+			if("engineering", "atmospherics")
 				radio_freq = FREQ_ENGINEERING
 			if("security")
 				radio_freq = FREQ_SECURITY
-			if("cargobay", "mining")
+			if("cargobay", "cargo", "mining", "salvage", "salvagebay")
 				radio_freq = FREQ_SUPPLY
+			if("service", "servicehall")
+				radio_freq = FREQ_SERVICE
 
 		var/datum/signal/subspace/messaging/rc/signal = new(src, list(
 			"sender" = department,


### PR DESCRIPTION
## About The Pull Request

- Fixes all requests consoles that were unset / incorrectly configured
- Adds a ton more requests consoles to places that were missing it (notably places like the CE's desk, QM's desk)
  - Tweaks the RC code for frequencies to accommodate
- Adds requests consoles to the faction rooms that people can announce from (neat)
- Adds a billion intercoms to cover up dead spaces 
   - I noticed the library had 0 intercom coverage but I figured it was intentional (quiet place?)
- Adds a million newscasters

![image](https://user-images.githubusercontent.com/51863163/187529729-2b8d7e18-780d-4fdb-871d-d62308cfbe85.png)

## Changelog

:cl: Melbert
add: Requests Consoles, Intercoms, Newscasters. 
/:cl:
