### PR TITLE
Armoury Gun Oversight Fix/Moderate Ballistics Overhaul

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -40,7 +40,7 @@
 	base_icon_state = "9x19p"
 	ammo_type = /obj/item/ammo_casing/c9mm
 	caliber = CALIBER_9MM
-	max_ammo = 8
+	max_ammo = 10
 
 /obj/item/ammo_box/magazine/m9mm/update_icon_state()
 	. = ..()
@@ -68,6 +68,7 @@
 	name = "pistol magazine (9mm FMJ)"
 	desc = "A gun magazine loaded with standard lethal rounds."
 	ammo_type = /obj/item/ammo_casing/c9mm/fmj
+
 
 /obj/item/ammo_box/magazine/m9mm_aps
 	name = "stechkin pistol magazine (9mm)"

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -25,7 +25,7 @@
 	name = "9mm FMJ bullet"
 	damage = 20
 	embedding = list(embed_chance=15, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
-
+	weak_against_armour = FALSE
 
 
 // 10mm

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -12,8 +12,9 @@
 
 /obj/projectile/bullet/a556/hp
 	name = "5.56mm hollowpoint bullet"
-	damage = 30
-	weak_against_armour = TRUE
+	damage = 20
+	weak_against_armour = FALSE
+	armour_penetration = -30
 	wound_bonus = 30
 
 /obj/projectile/bullet/a556/i
@@ -43,14 +44,15 @@
 
 /obj/projectile/bullet/a762/ap
 	name = "7.62 armour-piercing bullet"
-	damage = 40
+	damage = 50
 	armour_penetration = 50
 	wound_bonus = -30
 
 /obj/projectile/bullet/a762/hp
 	name = "7.62 hollowpoint bullet"
 	damage = 60
-	weak_against_armour = TRUE
+	weak_against_armour = FALSE
+	armour_penetration = -50
 	wound_bonus = 30
 
 /obj/projectile/bullet/a762/i

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -14,9 +14,10 @@
 
 /obj/projectile/bullet/c45/hp
 	name = ".45 hollowpoint bullet"
-	damage = 40
-	armour_penetration = -50
+	damage = 30
+	armour_penetration = -30
 	wound_bonus = 30
+	weak_against_armour = FALSE
 
 /obj/projectile/bullet/c45/i
 	name = ".45 incendiary bullet"
@@ -35,6 +36,7 @@
 	damage = 30
 	wound_bonus = -10
 	wound_falloff_tile = -10
+	weak_against_armour = FALSE
 
 /obj/projectile/bullet/incendiary/c45
 	name = ".45 incendiary bullet"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -71,7 +71,7 @@
 		"m45_fmj",
 		"m9mm",
 		"m9mm_fmj",
-		"smgm45",
+		"smgm45hp",
 		"a762",
 		"m556"
 	)
@@ -1381,7 +1381,7 @@
 		"a762hp",
 		"a762i",
 		"smgm45ap",
-		"smgm45hp",
+		"smgm45",
 		"smgm45i"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)

--- a/starbloom_modules/aesthetics/guns/code/guns.dm
+++ b/starbloom_modules/aesthetics/guns/code/guns.dm
@@ -312,6 +312,7 @@
 	fire_sound = 'sound/weapons/gun/pistol/starbloom_45.ogg'
 	burst_size = 2
 	icon = 'starbloom_modules/aesthetics/guns/icons/guns.dmi'
+	mag_type = /obj/item/ammo_box/magazine/smgm45/hp
 
 /obj/item/gun/ballistic/automatic/ar/modular/model75
 	name = "\improper NT ARG-75"

--- a/starbloom_modules/aesthetics/guns/code/guns.dm
+++ b/starbloom_modules/aesthetics/guns/code/guns.dm
@@ -114,7 +114,7 @@
 	worn_icon_state = "gun"
 	worn_icon = null
 
-/obj/item/gun/energy/laser/thermal 
+/obj/item/gun/energy/laser/thermal
 	icon = 'icons/obj/guns/energy.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
@@ -247,8 +247,9 @@
 	fire_sound = 'sound/weapons/gun/pistol/starbloom_9mm.ogg'
 	icon_state = "arg"
 	inhand_icon_state = "arg"
-	burst_size = 2
+	burst_size = 3
 	can_suppress = FALSE
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/gun/ballistic/automatic/ar/modular/solrifle
 	name = "MCRS-5B ICWS"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the 5.56 Valiant a Bulky weapon, and ups the burst rate from 2 round burst to 3 round burst, so that its per-burst damage output matches the .45

I wanted to keep any major changes to a minimum, as I remember Sylphet talking about wanting to do some rebalancing primarily through making Armour more valuable, so I've tried to keep everything as close to the same as possible to not get in the way of that. But if there are any other changes wanted from me here, or anything in this you want changed back, I'd be happy to! This is my first PR ever on any codebase, so I hope I'm doing this properly :V I'm kinda just winging it as I go.

After further conversation with Sylphet, further tweaks have been made. 
## Why It's Good For The Game

I thought it was strange that both the .45 SMG and the 5.56 Rifle were considered Normal sized. On top of this, the .45 had a 2 round burst of 30 damage, per shot and the 5.56 had a 2 round burst of 20 damage per shot, with their basic ammo types. I bumped up the 5.56 to a 3 round burst of 20 damage per shot to put its damage-per-burst on par with the .45 so that it isn't a direct downgrade in every possible way.

FMJ rounds get dunked on by armour decently well and we can worry about any changes needed there, later. HP's will at least do SOMETHING to armour, but will be massively reduced. Testing revealed that AP reduces by a flat %. 50 AP will turn a Level 6 Bullet Resist's 60% down to 10%. HP at -30 will mean that even a level 1 10% vest will reduce their damage by 40%. We also want the handguns to be remotely useful if the target has literally anything armour based on.

However, doing this would undermine the SMG's niche as being Good Against Unarmoured, Shit Against Armour, so we've tweaked it slightly so that the .45 Helios and our techweb starts with .45 SMG Hollowpoints, with FMJ access being available later through techweb research.

The 9mm pistol can also have an ammo capacity of 10 as it is weaker than the others. As a treat. :)
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Bumped up the 5.56 Valiant's burst size to fix the discrepancy in damage-per-burst with the .45
fix: The 5.56 Valiant was probably not supposed to be Normal sized. This has been fixed.
balance: Reduced Hollowpoint Damage to FMJ Levels
balance: Made sure Hollowpoint rounds have Wound BOnuses
balance: Removed Hollowpoint weakagainstarmour
balance: Reduced Hollowpoint AP to -30
balance: Removed 9mm and .45 FMJ weakagainstarmour
balance: Increased 9mm magazine capacity to 10 rounds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
