### PR TITLE
Large construction paper bin

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -28455,8 +28455,13 @@
 /area/service/library/lounge)
 "idM" = (
 /obj/structure/table,
-/obj/item/storage/box/pdas,
+/obj/item/storage/box/pdas{
+	pixel_x = 10
+	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/item/paper_bin/construction/large{
+	pixel_x = -6
+	},
 /turf/open/floor/iron/dark/blue/side,
 /area/command/heads_quarters/hop)
 "idO" = (

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -233,5 +233,11 @@
 	papertype = /obj/item/paper/carbon
 	bin_overlay_string = "paper_bin_carbon_overlay"
 
+/obj/item/paper_bin/construction/large
+	name = "large construction paper bin"
+	desc = "Contains all the paper you'll never need, IN COLOR!"
+	papertype = /obj/item/paper/construction
+	total_paper = 120
+
 #undef PAPERS_PER_OVERLAY
 #undef PAPER_OVERLAY_PIXEL_SHIFT


### PR DESCRIPTION
A large construction paper bin has been added to the HoPs office

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A bin with 120 colored papers for the complex paperwork they must be doing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
An easy way to get colored paper without having to raid the CE office or use up spraycans.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Large construction paper bin now in HoP's Office.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
