### PR TITLE
.45 SMG Magazine bug fixes, featuring: .45 Rubber Pistol magazines loaded with AP

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -21,6 +21,7 @@
 /obj/item/ammo_casing/c45
 	name = ".45 rubber bullet casing"
 	desc = "A .45 rubber bullet casing."
+	caliber = CALIBER_45
 	projectile_type = /obj/projectile/bullet/c45
 
 /obj/item/ammo_casing/c45/ap
@@ -41,7 +42,6 @@
 /obj/item/ammo_casing/c45/fmj
 	name = ".45 FMJ bullet casing"
 	desc = "A .45 FMJ bullet casing."
-	caliber = CALIBER_45
 	projectile_type = /obj/projectile/bullet/c45/fmj
 
 /obj/item/ammo_casing/c45/inc

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -75,12 +75,13 @@
 	ammo_type = /obj/item/ammo_casing/c9mm/fire
 
 /obj/item/ammo_box/magazine/smgm45
-	name = "SMG magazine (.45 FMJ)"
+	name = "SMG magazine (.45 HP)"
 	icon_state = "c20r45-24"
 	base_icon_state = "c20r45"
-	ammo_type = /obj/item/ammo_casing/c45/fmj
+	ammo_type = /obj/item/ammo_casing/c45/hp
 	caliber = CALIBER_45
 	max_ammo = 24
+
 
 /obj/item/ammo_box/magazine/smgm45/update_icon_state()
 	. = ..()
@@ -98,11 +99,11 @@
 	. = ..()
 	icon_state = "[base_icon_state]-[round(ammo_count(), 2)]"
 
-/obj/item/ammo_box/magazine/smgm45/hp
-	name = "SMG magazine (.45 HP)"
+/obj/item/ammo_box/magazine/smgm45/fmj
+	name = "SMG magazine (.45 FMJ)"
 	icon_state = "c20r45-24"
 	base_icon_state = "c20r45"
-	ammo_type = /obj/item/ammo_casing/c45/hp
+	ammo_type = /obj/item/ammo_casing/c45/fmj
 	caliber = CALIBER_45
 	max_ammo = 24
 

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -190,7 +190,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/smgm45
-	name = "Magazine (.45 FMJ - SMG)"
+	name = "Magazine (.45 HP - SMG)"
 	desc = "Designed to quickly reload the Helios PDW."
 	id = "smgm45"
 	build_type = PROTOLATHE | AWAY_LATHE
@@ -209,13 +209,13 @@
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/smgm45hp
-	name = "Magazine (.45 HP - SMG)"
+/datum/design/smgm45fmj
+	name = "Magazine (.45 FMJ - SMG)"
 	desc = "Designed to quickly reload the Helios PDW. Hollowpoints expand on impact, but are stopped easily by armour."
-	id = "smgm45hp"
+	id = "smgm45fmj"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 40000, /datum/material/gold = 5000)
-	build_path = /obj/item/ammo_box/magazine/smgm45/hp
+	build_path = /obj/item/ammo_box/magazine/smgm45/fmj
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -71,7 +71,7 @@
 		"m45_fmj",
 		"m9mm",
 		"m9mm_fmj",
-		"smgm45hp",
+		"smgm45",
 		"a762",
 		"m556"
 	)
@@ -1381,7 +1381,7 @@
 		"a762hp",
 		"a762i",
 		"smgm45ap",
-		"smgm45",
+		"smgm45fmj",
 		"smgm45i"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)

--- a/starbloom_modules/aesthetics/guns/code/guns.dm
+++ b/starbloom_modules/aesthetics/guns/code/guns.dm
@@ -312,7 +312,7 @@
 	fire_sound = 'sound/weapons/gun/pistol/starbloom_45.ogg'
 	burst_size = 2
 	icon = 'starbloom_modules/aesthetics/guns/icons/guns.dmi'
-	mag_type = /obj/item/ammo_box/magazine/smgm45/hp
+	mag_type = /obj/item/ammo_box/magazine/smgm45
 
 /obj/item/gun/ballistic/automatic/ar/modular/model75
 	name = "\improper NT ARG-75"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In my initial PR about Fixing Some Gun Stuff, I accidentally made a little mistake that meant that the .45 Helios was only able to load Hollowpoint magazines.

This has now been fixed. I've also doublechecked that you can research .45 SMG FMJ magazines as during my testing while I was working on fixing this, I managed to make it so you couldn't.

ALSO, despite printing .45 SMG HP magazines, the Sec Techfab listing for them was Magazine .45 FMJ SMG; this has ALSO been fixed.

And lastly, while I was working on it, I noticed that when changes were made in the past that made .45 Rubbers the default .45 type, this resulted in .45 FMJ being the only type of .45 Casing that could be put INTO a Magazine. In other words, if you had AP, HP or Rubbers and you accidentally racked the slide/bolt? Your mag was one round less and you couldn't fix it without just getting a new one. This has been fixed.

This ALSO, however, means that a .45 (FMJ) magazine can be loaded with .45 (HP) bullets, for example. This applies to both Handgun and SMG. This should give antags some opportunities for fun if they can get their hands on a .45 Pistol and some AP ammo, mayhaps ;)

Or you could load your .45 Helios with Rubbers for high fire-rate AND capacity less-than-lethal police brutality!

## Why It's Good For The Game

Bug and oversight fixes are good.

## Changelog
:cl:
balance: Technically, .45 Casings not being able to be loaded into Magazines properly is an oversight, but it does have an interesting result on things when fixed, so we're putting it here.
fix: Fixed Weird Gun Bugs involving .45 Ammunition and Weaponry.
/:cl:
