### PR TITLE
Refines Tyrant Suit, makes high slowdown armor unable to ride scooters.

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -47109,7 +47109,7 @@
 	name = "Heavy Armor Storage"
 	},
 /obj/item/clothing/suit/armor/heavy,
-/obj/item/clothing/head/helmet/marine/tyrant,
+/obj/item/clothing/head/helmet/tyrant,
 /turf/open/floor/iron/dark/red,
 /area/ai_monitored/security/armory)
 "nkw" = (

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -127,11 +127,26 @@
 	name = "marine medic helmet"
 	icon_state = "marine_medic"
 
-/obj/item/clothing/head/helmet/marine/tyrant
+/obj/item/clothing/head/helmet/tyrant
 	name = "TYRANT helmet"
 	desc = "An extremely heavily armored helmet that protects against moderate damage. It's Class IV armor, offering near total protection against projectiles."
 	w_class = WEIGHT_CLASS_BULKY
+	icon_state = "marine_command"
+	inhand_icon_state = "helmetalt"
+	slowdown = 1
+	equip_delay_self = 50
+	equip_delay_other = 75
+	strip_delay = 100
+	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor = list(MELEE = 90, BULLET = 95, LASER = 80, ENERGY = 80, BOMB = 100, BIO = 100, FIRE = 90, ACID = 90)
+	can_flashlight = TRUE
+	dog_fashion = null //would probably break a corgi's neck
+
+/obj/item/clothing/head/helmet/tyrant/Initialize(mapload)
+	set_attached_light(new /obj/item/flashlight/seclite)
+	update_helmlight()
+	update_appearance()
+	. = ..()
 
 /obj/item/clothing/head/helmet/old
 	name = "degrading helmet"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -257,10 +257,10 @@
 	w_class = WEIGHT_CLASS_BULKY
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	equip_delay_self = 200
-	equip_delay_other = 200
-	strip_delay = 200
-	slowdown = 4
+	equip_delay_self = 50
+	equip_delay_other = 75
+	strip_delay = 100 //10 seconds, you'll have to wait a while.
+	slowdown = 2.5
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	armor = list(MELEE = 90, BULLET = 95, LASER = 80, ENERGY = 80, BOMB = 100, BIO = 100, FIRE = 90, ACID = 90)
 

--- a/code/modules/vehicles/ridden.dm
+++ b/code/modules/vehicles/ridden.dm
@@ -68,3 +68,15 @@
 /obj/vehicle/ridden/zap_act(power, zap_flags)
 	zap_buckle_check(power)
 	return ..()
+
+/obj/vehicle/ridden/relaymove(mob/living/user, direction)
+	if(ishuman(user))
+		var/mob/living/carbon/human/target = user
+		if(target.wear_suit)
+			var/obj/item/clothing/target_suit = target.wear_suit
+			if(target_suit.slowdown >= 2.5) //If our clothing's too thicc, we can't ride.
+				to_chat(user, span_warning("You are too heavy for the [src] to move!"))
+				canmove = FALSE
+				addtimer(VARSET_CALLBACK(src, canmove, TRUE), 2 SECONDS)
+				return FALSE
+	return ..()


### PR DESCRIPTION
## About The Pull Request

This PR refines the Tyrant Suit. The helmet now has slowdown, slowdown on the armor is very slightly reduced and the armor no longer takes 20 seconds to put on.

Aswell, 2.5+ slowdown armor makes you unable to ride any vehicle which is a "ridden" subtype, so basically everything you can think of to exploit high-slowdown armors with.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/13697285/192122817-277c5da2-d3e6-4b29-85c8-823a7464fe8e.png)
No using scooters to offset your immense weight!

In addition, the helmet now has slowdown to prevent it from being the best helmet around. It also has an equip delay now so you can't tactically take off the helmet.

Equip time was reduced on the suit because you need to put on the helmet and also because 20 seconds is a downright insane amount of time.

## Changelog

:cl:
balance: Refined the TYRANT suit overall, changing it's balancing in many values. Try it now!
balance: Scooters, secways and skateboards can no longer support heavy armors.
/:cl: