### PR TITLE
[TG Mirror] fixes a check in `/datum/callback/Invoke`

### DIFF
--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -124,7 +124,7 @@
 		else
 			calling_arguments = args
 	if(datum_flags & DF_VAR_EDITED)
-		if(usr && usr != GLOB.AdminProcCallHandler && !usr.client?.ckey) //This ONLY happens when usr's client switches mobs just before the callback gets invoked.
+		if(usr != GLOB.AdminProcCallHandler && !usr?.client?.ckey) //This happens when a timer or the MC invokes a callback
 			return HandleUserlessProcCall(usr, object, delegate, calling_arguments)
 		return WrapAdminProcCall(object, delegate, calling_arguments)
 	if (object == GLOBAL_PROC)
@@ -161,7 +161,7 @@
 		else
 			calling_arguments = args
 	if(datum_flags & DF_VAR_EDITED)
-		if(usr != GLOB.AdminProcCallHandler && !usr?.client?.ckey) //This happens when a timer invokes a callback
+		if(usr != GLOB.AdminProcCallHandler && !usr?.client?.ckey) //This happens when a timer or the MC invokes a callback
 			return HandleUserlessProcCall(usr, object, delegate, calling_arguments)
 		return WrapAdminProcCall(object, delegate, calling_arguments)
 	if (object == GLOBAL_PROC)


### PR DESCRIPTION
## About The Pull Request

This PR is a port of tgstation/tgstation#70172. From the original PR:
> In a prior PR related to admin lua scripting, I had updated /datum/callback/InvokeAsync so that varedited callbacks don't runtime with a "WrapAdminProcCall with no ckey" error when called by a timer, or anything else called in the proc chain of the MC firing. I hadn't applied this fix to /datum/callback/Invoke, which meant that aforementioned runtime would still occur when such varedited callbacks were invoked synchronously by the MC. This PR fixes that.

## Why It's Good For The Game

From the original PR:
> This fixes a lot of signal handling issues with admin lua scripting (which I know is broken in 514.1588, but that's because willox needs to update the function signatures for auxtools).

## Changelog

:cl:
fix: Fixed a runtime that happens when the MC invokes a varedited callback synchronously.
/:cl:
