### PR TITLE
Fixes Dreamseeker / Makes it default launch option

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,18 +2,6 @@
 	"version": "0.2.0",
 	"configurations": [
 		{
-			"name": "Debug External Libraries",
-			"type": "cppvsdbg",
-			"request": "launch",
-			"program": "${command:dreammaker.returnDreamDaemonPath}",
-			"cwd": "${workspaceRoot}",
-			"args": [
-				"${command:dreammaker.getFilenameDmb}",
-				"-trusted"
-			],
-			"preLaunchTask": "Build All"
-		},
-		{
 			"type": "byond",
 			"request": "launch",
 			"name": "Launch DreamSeeker",
@@ -27,6 +15,18 @@
 			"preLaunchTask": "Build All",
 			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
 			"dreamDaemon": true
+		},
+		{
+			"name": "Debug External Libraries",
+			"type": "cppvsdbg",
+			"request": "launch",
+			"program": "${command:dreammaker.returnDreamDaemonPath}",
+			"cwd": "${workspaceRoot}",
+			"args": [
+				"${command:dreammaker.getFilenameDmb}",
+				"-trusted"
+			],
+			"preLaunchTask": "Build All"
 		}
 	]
 }

--- a/html/changelogs/AutoChangeLog-pr-70357.yml
+++ b/html/changelogs/AutoChangeLog-pr-70357.yml
@@ -1,0 +1,6 @@
+author: "RikuTheKiller"
+delete-after: True
+changes: 
+  - bugfix: "Fixed brains not accepting mannitol pours when not fully decayed"
+  - qol: "Mannitol solutions are now only partially consumed when poured on a brain and you don't need 10u to do so"
+  - qol: "Pouring mannitol on a brain now takes 3 seconds instead of 6 seconds and the messages are slightly more consistent"

--- a/html/changelogs/AutoChangeLog-pr-70357.yml
+++ b/html/changelogs/AutoChangeLog-pr-70357.yml
@@ -1,6 +1,0 @@
-author: "RikuTheKiller"
-delete-after: True
-changes: 
-  - bugfix: "Fixed brains not accepting mannitol pours when not fully decayed"
-  - qol: "Mannitol solutions are now only partially consumed when poured on a brain and you don't need 10u to do so"
-  - qol: "Pouring mannitol on a brain now takes 3 seconds instead of 6 seconds and the messages are slightly more consistent"


### PR DESCRIPTION
## About The Pull Request

Port. Side effect from the AdminLUA pulls, never got fixed down here.

Makes Dreamseeker defualt launch option for compiling from VScode. Also makes it work.

Makes it much easier to compile and run code quickly