### PR TITLE
The testmergable cargo/security/home guard gun content expansion PR, part one.

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -272,12 +272,13 @@
 	crate_type = /obj/structure/closet/crate/cardboard/mothic
 
 //////////////////////////////////////////////////////////////////////////////
-//////////////////////////// Security ////////////////////////////////////////
+//////////////////////////// Security Materiel and Supplies ////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/security
-	group = "Security"
+	group = "Security Materiel and supplies"
 	access = ACCESS_SECURITY
+	access_view = ACCESS_SECURITY
 	crate_type = /obj/structure/closet/crate/secure/gear
 
 /datum/supply_pack/security/ammo
@@ -316,7 +317,26 @@
 					/obj/item/gun/energy/disabler)
 	crate_name = "disabler crate"
 
-/datum/supply_pack/security/forensics
+/datum/supply_pack/security/armory/dragnet
+	name = "DRAGnet Crate"
+	desc = "Contains three \"Dynamic Rapid-Apprehension of the Guilty\" netting devices, a recent breakthrough in law enforcement prisoner management technology. Requires armory access to open."
+	cost = CARGO_CRATE_VALUE * 5
+	contains = list(/obj/item/gun/energy/e_gun/dragnet,
+					/obj/item/gun/energy/e_gun/dragnet,
+					/obj/item/gun/energy/e_gun/dragnet)
+	crate_name = "\improper DRAGnet crate"
+
+/datum/supply_pack/security/armory/energy
+	name = "Energy Guns Crate"
+	desc = "Contains two Energy Guns, capable of firing both nonlethal and lethal blasts of light. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 18
+	contains = list(/obj/item/gun/energy/e_gun,
+					/obj/item/gun/energy/e_gun)
+	crate_name = "energy gun crate"
+	crate_type = /obj/structure/closet/crate/secure/plasma
+
+
+	/datum/supply_pack/security/forensics
 	name = "Forensics Crate"
 	desc = "Stay hot on the criminal's heels with Nanotrasen's Detective Essentials(tm). Contains a forensics scanner, six evidence bags, camera, tape recorder, white crayon, and of course, a fedora. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2.5
@@ -338,26 +358,35 @@
 					/obj/item/clothing/head/helmet/sec)
 	crate_name = "helmet crate"
 
-/datum/supply_pack/security/laser
-	name = "Lasers Crate"
-	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 4
-	access_view = ACCESS_ARMORY
-	contains = list(/obj/item/gun/energy/laser,
-					/obj/item/gun/energy/laser,
-					/obj/item/gun/energy/laser)
-	crate_name = "laser crate"
+/datum/supply_pack/security/justiceinbound
+	name = "Standard Justice Enforcer Crate"
+	desc = "This is it. The Bee's Knees. The Creme of the Crop. The Pick of the Litter. The best of the best of the best. The Crown Jewel of Nanotrasen. The Alpha and the Omega of security headwear. Guaranteed to strike fear into the hearts of each and every criminal aboard the station. Also comes with a security gasmask. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 6 //justice comes at a price. An expensive, noisy price.
+	contraband = TRUE
+	contains = list(/obj/item/clothing/head/helmet/justice,
+					/obj/item/clothing/mask/gas/sechailer)
+	crate_name = "security clothing crate"
 
-/datum/supply_pack/security/securitybarriers
-	name = "Security Barrier Grenades"
-	desc = "Stem the tide with four Security Barrier grenades. Requires Security access to open."
-	access_view = ACCESS_BRIG
-	contains = list(/obj/item/grenade/barrier,
-					/obj/item/grenade/barrier,
-					/obj/item/grenade/barrier,
-					/obj/item/grenade/barrier)
+/datum/supply_pack/security/baton
+	name = "Stun Batons Crate"
+	desc = "Arm the Civil Protection Forces with three stun batons. Batteries included. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2
-	crate_name = "security barriers crate"
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/melee/baton/security/loaded,
+					/obj/item/melee/baton/security/loaded,
+					/obj/item/melee/baton/security/loaded)
+	crate_name = "stun baton crate"
+
+/datum/supply_pack/security/constable
+	name = "Traditional Equipment Crate"
+	desc = "Spare equipment found in a warehouse."
+	cost = CARGO_CRATE_VALUE * 2.2
+	contraband = TRUE
+	contains = list(/obj/item/clothing/under/rank/security/constable,
+					/obj/item/clothing/head/helmet/constable,
+					/obj/item/clothing/gloves/color/white,
+					/obj/item/clothing/mask/whistle,
+					/obj/item/conversion_kit)
 
 /datum/supply_pack/security/securityclothes
 	name = "Security Clothing Crate"
@@ -378,14 +407,6 @@
 					/obj/item/clothing/head/hos/beret/navyhos)
 	crate_name = "security clothing crate"
 
-/datum/supply_pack/security/stingpack
-	name = "Stingbang Grenade Pack"
-	desc = "Contains five \"stingbang\" grenades, perfect for stopping riots and playing morally unthinkable pranks. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 5
-	access_view = ACCESS_ARMORY
-	contains = list(/obj/item/storage/box/stingbangs)
-	crate_name = "stingbang grenade pack crate"
-
 /datum/supply_pack/security/supplies
 	name = "Security Supplies Crate"
 	desc = "Contains seven flashbangs, seven teargas grenades, six flashes, and seven handcuffs. Requires Security access to open."
@@ -397,44 +418,7 @@
 					/obj/item/storage/box/handcuffs)
 	crate_name = "security supply crate"
 
-/datum/supply_pack/security/firingpins
-	name = "Standard Firing Pins Crate"
-	desc = "Upgrade your arsenal with 10 standard firing pins. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 4
-	access_view = ACCESS_ARMORY
-	contains = list(/obj/item/storage/box/firingpins,
-					/obj/item/storage/box/firingpins)
-	crate_name = "firing pins crate"
-
-/datum/supply_pack/security/firingpins/paywall
-	name = "Paywall Firing Pins Crate"
-	desc = "Specialized firing pins with a built-in configurable paywall. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 2
-	access_view = ACCESS_ARMORY
-	contains = list(/obj/item/storage/box/firingpins/paywall,
-					/obj/item/storage/box/firingpins/paywall)
-	crate_name = "paywall firing pins crate"
-
-/datum/supply_pack/security/justiceinbound
-	name = "Standard Justice Enforcer Crate"
-	desc = "This is it. The Bee's Knees. The Creme of the Crop. The Pick of the Litter. The best of the best of the best. The Crown Jewel of Nanotrasen. The Alpha and the Omega of security headwear. Guaranteed to strike fear into the hearts of each and every criminal aboard the station. Also comes with a security gasmask. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 6 //justice comes at a price. An expensive, noisy price.
-	contraband = TRUE
-	contains = list(/obj/item/clothing/head/helmet/justice,
-					/obj/item/clothing/mask/gas/sechailer)
-	crate_name = "security clothing crate"
-
-/datum/supply_pack/security/baton
-	name = "Stun Batons Crate"
-	desc = "Arm the Civil Protection Forces with three stun batons. Batteries included. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 2
-	access_view = ACCESS_SECURITY
-	contains = list(/obj/item/melee/baton/security/loaded,
-					/obj/item/melee/baton/security/loaded,
-					/obj/item/melee/baton/security/loaded)
-	crate_name = "stun baton crate"
-
-/datum/supply_pack/security/wall_flash
+	/datum/supply_pack/security/wall_flash
 	name = "Wall-Mounted Flash Crate"
 	desc = "Contains four wall-mounted flashes. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2
@@ -444,25 +428,13 @@
 					/obj/item/storage/box/wall_flash)
 	crate_name = "wall-mounted flash crate"
 
-/datum/supply_pack/security/constable
-	name = "Traditional Equipment Crate"
-	desc = "Spare equipment found in a warehouse."
-	cost = CARGO_CRATE_VALUE * 2.2
-	contraband = TRUE
-	contains = list(/obj/item/clothing/under/rank/security/constable,
-					/obj/item/clothing/head/helmet/constable,
-					/obj/item/clothing/gloves/color/white,
-					/obj/item/clothing/mask/whistle,
-					/obj/item/conversion_kit)
-
 //////////////////////////////////////////////////////////////////////////////
-//////////////////////////// Armory //////////////////////////////////////////
+//////////////////////////// Armory Materiel and Supplies //////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
-
 /datum/supply_pack/security/armory
-	group = "Armory"
+	group = "Armory Materiel and Supplies"
 	access = ACCESS_ARMORY
-	access_view = ACCESS_ARMORY
+	acces_view = ACCESS_ARMORY
 	crate_type = /obj/structure/closet/crate/secure/weapon
 
 /datum/supply_pack/security/armory/bulletarmor
@@ -483,14 +455,7 @@
 					/obj/item/clothing/head/helmet/alt)
 	crate_name = "bulletproof helmets crate"
 
-/datum/supply_pack/security/armory/chemimp
-	name = "Chemical Implants Crate"
-	desc = "Contains five Remote Chemical implants. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 3.5
-	contains = list(/obj/item/storage/box/chemimp)
-	crate_name = "chemical implant crate"
-
-/datum/supply_pack/security/armory/ballistic
+	/datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
 	desc = "For when the enemy absolutely needs to be replaced with lead. Contains three Aussec-designed Combat Shotguns, and three Shotgun Bandoliers. Requires Armory access to open."
 	cost = CARGO_CRATE_VALUE * 17.5
@@ -501,31 +466,6 @@
 					/obj/item/storage/belt/bandolier,
 					/obj/item/storage/belt/bandolier)
 	crate_name = "combat shotguns crate"
-
-/datum/supply_pack/security/armory/dragnet
-	name = "DRAGnet Crate"
-	desc = "Contains three \"Dynamic Rapid-Apprehension of the Guilty\" netting devices, a recent breakthrough in law enforcement prisoner management technology. Requires armory access to open."
-	cost = CARGO_CRATE_VALUE * 5
-	contains = list(/obj/item/gun/energy/e_gun/dragnet,
-					/obj/item/gun/energy/e_gun/dragnet,
-					/obj/item/gun/energy/e_gun/dragnet)
-	crate_name = "\improper DRAGnet crate"
-
-/datum/supply_pack/security/armory/energy
-	name = "Energy Guns Crate"
-	desc = "Contains two Energy Guns, capable of firing both nonlethal and lethal blasts of light. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 18
-	contains = list(/obj/item/gun/energy/e_gun,
-					/obj/item/gun/energy/e_gun)
-	crate_name = "energy gun crate"
-	crate_type = /obj/structure/closet/crate/secure/plasma
-
-/datum/supply_pack/security/armory/exileimp
-	name = "Exile Implants Crate"
-	desc = "Contains five Exile implants. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 3.5
-	contains = list(/obj/item/storage/box/exileimp)
-	crate_name = "exile implant crate"
 
 /datum/supply_pack/security/armory/fire
 	name = "Incendiary Weapons Crate"
@@ -542,23 +482,15 @@
 	crate_name = "incendiary weapons crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 	dangerous = TRUE
-
-/datum/supply_pack/security/armory/mindshield
-	name = "Mindshield Implants Crate"
-	desc = "Prevent against radical thoughts with three Mindshield implants. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 6
-	contains = list(/obj/item/storage/lockbox/loyalty)
-	crate_name = "mindshield implant crate"
-
-/datum/supply_pack/security/armory/trackingimp
-	name = "Tracking Implants Crate"
-	desc = "Contains four tracking implants and three tracking speedloaders of tracing .38 ammo. Requires Armory access to open."
-	cost = CARGO_CRATE_VALUE * 4.5
-	contains = list(/obj/item/storage/box/trackimp,
-					/obj/item/ammo_box/c38/trac,
-					/obj/item/ammo_box/c38/trac,
-					/obj/item/ammo_box/c38/trac)
-	crate_name = "tracking implant crate"
+/datum/supply_pack/security/laser
+	name = "Lasers Crate"
+	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 4
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/gun/energy/laser,
+					/obj/item/gun/energy/laser,
+					/obj/item/gun/energy/laser)
+	crate_name = "laser crate"
 
 /datum/supply_pack/security/armory/laserarmor
 	name = "Reflector Vest Crate"
@@ -569,6 +501,14 @@
 	crate_name = "reflector vest crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
+/datum/supply_pack/security/firingpins/paywall
+	name = "Paywall Firing Pins Crate"
+	desc = "Specialized firing pins with a built-in configurable paywall. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/storage/box/firingpins/paywall,
+					/obj/item/storage/box/firingpins/paywall)
+	crate_name = "paywall firing pins crate"
 /datum/supply_pack/security/armory/riotarmor
 	name = "Riot Armor Crate"
 	desc = "Contains three sets of heavy body armor. Advanced padding protects against close-ranged weaponry, making melee attacks feel only half as potent to the user. Requires Armory access to open."
@@ -596,7 +536,7 @@
 					/obj/item/shield/riot)
 	crate_name = "riot shields crate"
 
-/datum/supply_pack/security/armory/russian
+	/datum/supply_pack/security/armory/russian
 	name = "Russian Surplus Crate"
 	desc = "Hello Comrade, we have the most modern russian military equipment the black market can offer, for the right price of course. Sadly we couldnt remove the lock so it requires Armory access to open."
 	cost = CARGO_CRATE_VALUE * 12
@@ -623,6 +563,34 @@
 		var/item = pick(contains)
 		new item(C)
 
+
+/datum/supply_pack/security/securitybarriers
+	name = "Security Barrier Grenades"
+	desc = "Stem the tide with four Security Barrier grenades. Requires Security access to open."
+	access_view = ACCESS_BRIG
+	contains = list(/obj/item/grenade/barrier,
+					/obj/item/grenade/barrier,
+					/obj/item/grenade/barrier,
+					/obj/item/grenade/barrier)
+	cost = CARGO_CRATE_VALUE * 2
+	crate_name = "security barriers crate"
+
+/datum/supply_pack/security/stingpack
+	name = "Stingbang Grenade Pack"
+	desc = "Contains five \"stingbang\" grenades, perfect for stopping riots and playing morally unthinkable pranks. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 5
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/storage/box/stingbangs)
+	crate_name = "stingbang grenade pack crate"
+
+/datum/supply_pack/security/firingpins
+	name = "Standard Firing Pins Crate"
+	desc = "Upgrade your arsenal with 10 standard firing pins. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 4
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/storage/box/firingpins,
+					/obj/item/storage/box/firingpins)
+	crate_name = "firing pins crate"
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."
@@ -638,7 +606,6 @@
 					/obj/item/clothing/gloves/tackler/combat,
 					/obj/item/clothing/gloves/tackler/combat)
 	crate_name = "swat crate"
-
 /datum/supply_pack/security/armory/thermal
 	name = "Thermal Pistol Crate"
 	desc = "Contains a pair of holsters each with two experimental thermal pistols, using nanites as the basis for their ammo. Requires Armory access to open."
@@ -646,6 +613,52 @@
 	contains = list(/obj/item/storage/belt/holster/thermal,
 					/obj/item/storage/belt/holster/thermal)
 	crate_name = "thermal pistol crate"
+
+
+//////////////////////////////////////////////////////////////////////////////
+//////////////////////////// Brig Control Supplies ////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////
+
+/////// Almost everything in here is just depreciated content to be honest
+////// hence why it is sorted into it's own tab
+/datum/supply_pack/security/armory
+	group = "Brig Control Supplies"
+	access = ACCESS_ARMORY
+	access_view = ACCESS_ARMORY
+	crate_type = /obj/structure/closet/crate/secure/weapon
+
+/datum/supply_pack/security/armory/chemimp
+	name = "Chemical Implants Crate"
+	desc = "Contains five Remote Chemical implants. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 3.5
+	contains = list(/obj/item/storage/box/chemimp)
+	crate_name = "chemical implant crate"
+
+/datum/supply_pack/security/armory/exileimp
+	name = "Exile Implants Crate"
+	desc = "Contains five Exile implants. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 3.5
+	contains = list(/obj/item/storage/box/exileimp)
+	crate_name = "exile implant crate"
+
+/datum/supply_pack/security/armory/mindshield
+	name = "Mindshield Implants Crate"
+	desc = "Prevent against radical thoughts with three Mindshield implants. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 6
+	contains = list(/obj/item/storage/lockbox/loyalty)
+	crate_name = "mindshield implant crate"
+
+/datum/supply_pack/security/armory/trackingimp
+	name = "Tracking Implants Crate"
+	desc = "Contains four tracking implants and three tracking speedloaders of tracing .38 ammo. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 4.5
+	contains = list(/obj/item/storage/box/trackimp,
+					/obj/item/ammo_box/c38/trac,
+					/obj/item/ammo_box/c38/trac,
+					/obj/item/ammo_box/c38/trac)
+	crate_name = "tracking implant crate"
+
+
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Engineering /////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -522,7 +522,21 @@
 					/obj/item/ammo_box/c38/iceblox)
 	crate_name = "Live .38 ammo crate"
 
-
+/datum/supply_pack/security/handgunammo
+	name = "FMJhandgun Ammo Crate"
+	desc = "Contains FMJ ammo for the 9mm, .44 and .45. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 4
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/ammo_box/a44/fmj,
+					/obj/item/ammo_box/a44/fmj,
+					/obj/item/ammo_box/a44/fmj,
+					/obj/item/ammo_box/magazine/m45/fmj,
+					/obj/item/ammo_box/magazine/m45/fmj,
+					/obj/item/ammo_box/magazine/m45/fmj,
+					/obj/item/ammo_box/magazine/m9mm/fmj,
+					/obj/item/ammo_box/magazine/m9mm/fmj,
+					/obj/item/ammo_box/magazine/m9mm/fmj)
+	crate_name = "FMJ handgun ammo crate"
 /datum/supply_pack/security/armory/lethalshotgunammo
 	name = "buckshot shells cache"
 	desc = "Contains boxes of buckshot shells. Requires Armory access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -300,7 +300,7 @@
 	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/ammo_box/a44,
-					/obj/item/ammo_box/a44 ,
+					/obj/item/ammo_box/a44,
 					/obj/item/ammo_box/a44,
 					/obj/item/ammo_box/magazine/m45,
 					/obj/item/ammo_box/magazine/m45,
@@ -313,7 +313,7 @@
 /datum/supply_pack/security/detrubberammo
 	name = ".38 rubber Ammo Crate"
 	desc = "Contains less than lethal .38 speedloaders. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE *
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/ammo_box/c38/match/bouncy,
 					/obj/item/ammo_box/c38/match/bouncy,
@@ -364,7 +364,7 @@
 /datum/supply_pack/security/handguns
 	name = "Assorted handguns Crate"
 	desc = "Contains two 9mm pistols, two .44 revolvers and two .45 hand guns. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 8
+	cost = CARGO_CRATE_VALUE * 12
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/gun/ballistic/revolver/revolution,
 					/obj/item/gun/ballistic/revolver/revolution,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -525,7 +525,7 @@
 /datum/supply_pack/security/handgunammo
 	name = "FMJhandgun Ammo Crate"
 	desc = "Contains FMJ ammo for the 9mm, .44 and .45. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 8
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/ammo_box/a44/fmj,
 					/obj/item/ammo_box/a44/fmj,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -313,7 +313,7 @@
 /datum/supply_pack/security/detrubberammo
 	name = ".38 rubber Ammo Crate"
 	desc = "Contains less than lethal .38 speedloaders. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE *
+	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/ammo_box/c38/match/bouncy,
 					/obj/item/ammo_box/c38/match/bouncy,

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -272,40 +272,66 @@
 	crate_type = /obj/structure/closet/crate/cardboard/mothic
 
 //////////////////////////////////////////////////////////////////////////////
-//////////////////////////// Security Materiel and Supplies ////////////////////////////////////////
+//////////////////////////// Blue Alert Materiel and Supplies ////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
 /datum/supply_pack/security
-	group = "Security Materiel and supplies"
+	group = "Blue Alert Materiel and supplies"
 	access = ACCESS_SECURITY
 	access_view = ACCESS_SECURITY
 	crate_type = /obj/structure/closet/crate/secure/gear
 
-/datum/supply_pack/security/ammo
-	name = "Ammo Crate"
-	desc = "Contains three boxes of beanbag shotgun shells, three boxes of rubbershot shotgun shells and one of each special .38 speedloarders. Requires Security access to open."
-	cost = CARGO_CRATE_VALUE * 8
-	access_view = ACCESS_ARMORY
+/datum/supply_pack/security/LTLshotgunammo
+	name = "LTL Shotgun Ammo Crate"
+	desc = "Contains three boxes of beanbag shotgun shells and three boxes of rubbershot shotgun shells. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 4
+	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/storage/box/beanbag,
 					/obj/item/storage/box/beanbag,
 					/obj/item/storage/box/beanbag,
 					/obj/item/storage/box/rubbershot,
 					/obj/item/storage/box/rubbershot,
-					/obj/item/storage/box/rubbershot,
+					/obj/item/storage/box/rubbershot)
+	crate_name = "LTL shotgun ammo crate"
+
+/datum/supply_pack/security/LTLhandgunammo
+	name = "LTL handgun Ammo Crate"
+	desc = "Contains less than lethal ammo for the 9mm, .44 and .45. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 4
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/ammo_box/a44,
+					/obj/item/ammo_box/a44 ,
+					/obj/item/ammo_box/a44,
+					/obj/item/ammo_box/magazine/m45,
+					/obj/item/ammo_box/magazine/m45,
+					/obj/item/ammo_box/magazine/m45,
+					/obj/item/ammo_box/magazine/m9mm,
+					/obj/item/ammo_box/magazine/m9mm,
+					/obj/item/ammo_box/magazine/m9mm)
+	crate_name = "less than lethal handgun ammo crate"
+
+/datum/supply_pack/security/detrubberammo
+	name = ".38 rubber Ammo Crate"
+	desc = "Contains less than lethal .38 speedloaders. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE *
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/ammo_box/c38/match/bouncy,
+					/obj/item/ammo_box/c38/match/bouncy,
+					/obj/item/ammo_box/c38/match/bouncy,
+					/obj/item/ammo_box/c38/match/bouncy,
 					/obj/item/ammo_box/c38/trac,
-					/obj/item/ammo_box/c38/hotshot,
-					/obj/item/ammo_box/c38/iceblox)
+					/obj/item/ammo_box/c38/trac)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/security/armor
-	name = "Armor Crate"
+	name = "light Armor Crate"
 	desc = "Three vests of well-rounded, decently-protective armor. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest,
 					/obj/item/clothing/suit/armor/vest)
-	crate_name = "armor crate"
+	crate_name = "Light Armor Crate"
 
 /datum/supply_pack/security/disabler
 	name = "Disabler Crate"
@@ -335,6 +361,19 @@
 	crate_name = "energy gun crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
+/datum/supply_pack/security/handguns
+	name = "Assorted handguns Crate"
+	desc = "Contains two 9mm pistols, two .44 revolvers and two .45 hand guns. Requires Security access to open."
+	cost = CARGO_CRATE_VALUE * 8
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/gun/ballistic/revolver/revolution,
+					/obj/item/gun/ballistic/revolver/revolution,
+					/obj/item/gun/ballistic/automatic/pistol/equalizer,
+					/obj/item/gun/ballistic/automatic/pistol/equalizer,
+					/obj/item/gun/ballistic/automatic/pistol/liberator,
+					/obj/item/gun/ballistic/automatic/pistol/liberator)
+	crate_name = "Assorted handguns crate"
+	crate_type = /obj/structure/closet/crate/secure/plasma
 
 /datum/supply_pack/security/forensics
 	name = "Forensics Crate"
@@ -411,7 +450,7 @@
 	name = "Security Supplies Crate"
 	desc = "Contains seven flashbangs, seven teargas grenades, six flashes, and seven handcuffs. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 3.5
-	access_view = ACCESS_ARMORY
+	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/storage/box/flashbangs,
 					/obj/item/storage/box/teargas,
 					/obj/item/storage/box/flashes,
@@ -429,10 +468,10 @@
 	crate_name = "wall-mounted flash crate"
 
 //////////////////////////////////////////////////////////////////////////////
-//////////////////////////// Armory Materiel and Supplies //////////////////////////////////////////
+//////////////////////////// Red Alert Materiel and Supplies //////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 /datum/supply_pack/security/armory
-	group = "Armory Materiel and Supplies"
+	group = "Red Alert Materiel and Supplies"
 	access = ACCESS_ARMORY
 	access_view = ACCESS_ARMORY
 	crate_type = /obj/structure/closet/crate/secure/weapon
@@ -467,7 +506,33 @@
 					/obj/item/storage/belt/bandolier)
 	crate_name = "combat shotguns crate"
 
-/datum/supply_pack/security/armory/fire
+/datum/supply_pack/security/armory/lethaldetammo
+	name = ".38 ammo cache"
+	desc = "Contains Lethal and specialized .38 rounds. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 9
+	contains = list(/obj/item/ammo_box/c38/,
+					/obj/item/ammo_box/c38/,
+					/obj/item/ammo_box/c38/dumdum,
+					/obj/item/ammo_box/c38/dumdum,
+					/obj/item/ammo_box/c38/match,
+					/obj/item/ammo_box/c38/match,
+					/obj/item/ammo_box/c38/hotshot,
+					/obj/item/ammo_box/c38/hotshot,
+					/obj/item/ammo_box/c38/iceblox,
+					/obj/item/ammo_box/c38/iceblox)
+	crate_name = "Live .38 ammo crate"
+
+
+/datum/supply_pack/security/armory/lethalshotgunammo
+	name = "buckshot shells cache"
+	desc = "Contains boxes of buckshot shells. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 10
+	contains = list(/obj/item/storage/box/lethalshot,
+					/obj/item/storage/box/lethalshot,
+					/obj/item/storage/box/lethalshot)
+	crate_name = "buckshot shells crate"
+
+/datum/supply_pack/security/armory/flammenwerfer
 	name = "Incendiary Weapons Crate"
 	desc = "Burn, baby burn. Contains three incendiary grenades, three plasma canisters, and a flamethrower. Requires Armory access to open."
 	cost = CARGO_CRATE_VALUE * 7
@@ -482,6 +547,7 @@
 	crate_name = "incendiary weapons crate"
 	crate_type = /obj/structure/closet/crate/secure/plasma
 	dangerous = TRUE
+
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
 	desc = "Contains three lethal, high-energy laser guns. Requires Security access to open."
@@ -614,20 +680,6 @@
 	contains = list(/obj/item/storage/belt/holster/thermal,
 					/obj/item/storage/belt/holster/thermal)
 	crate_name = "thermal pistol crate"
-
-
-//////////////////////////////////////////////////////////////////////////////
-//////////////////////////// Brig Control Supplies ////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////
-
-/////// Almost everything in here is just depreciated content to be honest
-////// hence why it is sorted into it's own tab
-/datum/supply_pack/security/armory
-	group = "Brig Control Supplies"
-	access = ACCESS_ARMORY
-	access_view = ACCESS_ARMORY
-	crate_type = /obj/structure/closet/crate/secure/weapon
-
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
 	desc = "Contains five Remote Chemical implants. Requires Armory access to open."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -336,7 +336,7 @@
 	crate_type = /obj/structure/closet/crate/secure/plasma
 
 
-	/datum/supply_pack/security/forensics
+/datum/supply_pack/security/forensics
 	name = "Forensics Crate"
 	desc = "Stay hot on the criminal's heels with Nanotrasen's Detective Essentials(tm). Contains a forensics scanner, six evidence bags, camera, tape recorder, white crayon, and of course, a fedora. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2.5
@@ -418,7 +418,7 @@
 					/obj/item/storage/box/handcuffs)
 	crate_name = "security supply crate"
 
-	/datum/supply_pack/security/wall_flash
+/datum/supply_pack/security/wall_flash
 	name = "Wall-Mounted Flash Crate"
 	desc = "Contains four wall-mounted flashes. Requires Security access to open."
 	cost = CARGO_CRATE_VALUE * 2
@@ -434,7 +434,7 @@
 /datum/supply_pack/security/armory
 	group = "Armory Materiel and Supplies"
 	access = ACCESS_ARMORY
-	acces_view = ACCESS_ARMORY
+	access_view = ACCESS_ARMORY
 	crate_type = /obj/structure/closet/crate/secure/weapon
 
 /datum/supply_pack/security/armory/bulletarmor
@@ -455,7 +455,7 @@
 					/obj/item/clothing/head/helmet/alt)
 	crate_name = "bulletproof helmets crate"
 
-	/datum/supply_pack/security/armory/ballistic
+/datum/supply_pack/security/armory/ballistic
 	name = "Combat Shotguns Crate"
 	desc = "For when the enemy absolutely needs to be replaced with lead. Contains three Aussec-designed Combat Shotguns, and three Shotgun Bandoliers. Requires Armory access to open."
 	cost = CARGO_CRATE_VALUE * 17.5
@@ -536,7 +536,8 @@
 					/obj/item/shield/riot)
 	crate_name = "riot shields crate"
 
-	/datum/supply_pack/security/armory/russian
+
+/datum/supply_pack/security/armory/russian
 	name = "Russian Surplus Crate"
 	desc = "Hello Comrade, we have the most modern russian military equipment the black market can offer, for the right price of course. Sadly we couldnt remove the lock so it requires Armory access to open."
 	cost = CARGO_CRATE_VALUE * 12


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The security and armory tabs on the cargo ordering console have recieved substantial reorgnization, been renamed entirely and given a few new additions.

The security tab in the ordering console is now labelled as "blue alert materiel and supplies". and the armory tab is now the "red alert materiel and supplies"

the two ordering tabs are still largely the same, except for the following changes.

- laser rifle and stingbang crates were moved to the red alert ordering tab
- the security ammo box was renamed and repurposed to the "LTL shotgun ammo crate", with the specialized high-tech .38 speedloaders moved elsewhere.
- an "LTL handgun ammo" crate was added, containing magazines and speedloaders of rubber ammo for the m9mm, A44 and M45 hand guns.
- Another crate of ammo was added, this time for the det's .38 rubber speedloaders.
- the M9MM, A44 and M45 hand guns were given their own crate for purchasing hand guns in bulk, though this may be a temporary measure depending on future decisions. 
- And finally, more crates of ammo were added to the red alert ordering tab. One for buckshot, another containing FMJ ammo for the newly purchaseable hand guns and a last one for the detective's .38, which includes both the normal lethal and the specialized (but no less killy) high tech rounds.

And as the title indicates, this is but part one of the expansion project. Part two will be adding a means to acquire the .45 helios SMG, 5.56 Valiant assault rifle and 7.62 memoria rifle in a manner that is less easy than occupying cargo and making boxes disappear.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes it a bit easier to restock the armory, acquire ammo during a material deficit and run gun smuggling opfor's.
 These changes will also serve as a backbone for my next tyrannical copy+paste scheme.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added the M9MM, A44 and M45 hand guns to cargo, along with related ammo types to their own separate crates.
expansion: Expands content of an existing feature
qol: made an alternative method for acquiring ammunition.
balance: rebalanced the solitary ammunition box and gave detective a bit more leeway to get the funny ammo for the .38.


/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
