### PR TITLE
No More Gamer Moments

### DIFF
--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -409,8 +409,7 @@
 	// Executed when a gamer has lost
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	SEND_SIGNAL(human_holder, COMSIG_ADD_MOOD_EVENT, "gamer_lost", /datum/mood_event/gamer_lost)
-	// Executed asynchronously due to say()
-	INVOKE_ASYNC(src, .proc/gamer_moment)
+
 /**
  * Gamer is playing a game
  *
@@ -428,11 +427,6 @@
 		deltimer(gaming_withdrawal_timer)
 	gaming_withdrawal_timer = addtimer(CALLBACK(src, .proc/enter_withdrawal), GAMING_WITHDRAWAL_TIME, TIMER_STOPPABLE)
 
-
-/datum/quirk/gamer/proc/gamer_moment()
-	// It was a heated gamer moment...
-	var/mob/living/carbon/human/human_holder = quirk_holder
-	human_holder.say(";[pick("SHIT", "PISS", "FUCK", "CUNT", "COCKSUCKER", "MOTHERFUCKER")]!!", forced = name)
 
 /datum/quirk/gamer/proc/enter_withdrawal()
 	var/mob/living/carbon/human/human_holder = quirk_holder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the proc from the Gamer Quirk when you lose in a video game that was pretty much just the Tourettes genetics thing.

## Why It's Good For The Game

Forced speech, especially over Radio and especially just being random curse words is not suitable for HRP.

## Changelog

:cl:
qol: LRP quirk status deleted

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
