### PR TITLE
Further improves Alert Level messages

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -70,9 +70,9 @@ HUMANS_NEED_SURNAMES
 
 
 ## ALERT LEVELS ###
-ALERT_GREEN All threats to the Upper Deck have passed. Home Guard staff may not have weapons visible, privacy laws are once again fully enforced.
-ALERT_BLUE_UPTO The Unity have received reliable information about possible hostile activity towards the North Star. Home Guard staff may have weapons visible, random searches are permitted. Normal operations are not yet suspended.
-ALERT_BLUE_DOWNTO The immediate threat has passed. Home Guard staff may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed.
+ALERT_GREEN All threats to the Upper Deck have passed. Home Guard staff may not have weapons visible, privacy laws are once again fully enforced. 
+ALERT_BLUE_UPTO The Unity have received reliable information about possible hostile activity towards the North Star. Home Guard staff may have weapons visible, random searches are permitted. Crew are encouraged to remain vigilant, and alert the Home Guard to any suspicious activity, however Normal operations are not yet suspended.
+ALERT_BLUE_DOWNTO The immediate threat has passed and Crisis Protocols are now disabled. Crew are to return to standard operations. Home Guard staff may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed.
 ALERT_RED_UPTO Crisis Protocol is now in effect. Normal operations are suspended effective immediately until further notice. All members of a faction are to report to the head or department of that faction. Unaffiliated crew are to seek refuge at the Mekhane Temple, or to shelter in place if this is impossible. Please remain calm and rest assured that the Unity will handle this situation.
 ALERT_RED_DOWNTO The neutron purge has been deemed unnecessary and deactivated. There is still however an immediate serious threat to the North Star. Home Guard staff may have weapons unholstered at all times, random searches are allowed and advised. Crisis Protocol still in effect until further notice.
 ALERT_DELTA The Unity has chosen to activate the neutron purge. Any unprotected biological matter will be disintegrated. All crew are instructed to report to the nearest radiation shelter and await further instructions. Any orders from a member of Unity Command are absolute and must be followed. Any violations of these orders can be punished by death. This is not a drill.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -70,7 +70,7 @@ HUMANS_NEED_SURNAMES
 
 
 ## ALERT LEVELS ###
-ALERT_GREEN All threats to the Upper Deck have passed. Home Guard staff may not have weapons visible, privacy laws are once again fully enforced. 
+ALERT_GREEN All threats to the Upper Deck have passed. Home Guard staff may not have weapons visible, privacy laws are once again fully enforced. Crew are permitted to stand down from heightened alert, and resume previous activity. The Unity thanks you for your service.
 ALERT_BLUE_UPTO The Unity have received reliable information about possible hostile activity towards the North Star. Home Guard staff may have weapons visible, random searches are permitted. Crew are encouraged to remain vigilant, and alert the Home Guard to any suspicious activity, however Normal operations are not yet suspended.
 ALERT_BLUE_DOWNTO The immediate threat has passed and Crisis Protocols are now disabled. Crew are to return to standard operations. Home Guard staff may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed.
 ALERT_RED_UPTO Crisis Protocol is now in effect. Normal operations are suspended effective immediately until further notice. All members of a faction are to report to the head or department of that faction. Unaffiliated crew are to seek refuge at the Mekhane Temple, or to shelter in place if this is impossible. Please remain calm and rest assured that the Unity will handle this situation.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I really liked what Axel was doing with the Alert Levels, but I thought that we could benefit from enhancing them slightly further.

## Why It's Good For The Game

In a vacuum, one after the other, mentioning that Crisis Mode is disabled and Normal Operations are Restored is redundant. They were activated with the raise to Red, so clearly the drop down from Red will be obvious. But if the drop from Red to Blue is upwards of an hour later, it can be easy to forget. So a small message mentioning the disabling of Crisis Protocols and restoration of Standard Operations could be beneficial.

Of course, what if we drop down to Green? We'd have nothing. But we can't have something JUST for Red -> Green. So I added to Blue a little bit of flavour encouraging the Crew to have heightened awareness, so that our Green message can encourage the Crew to return to normal as well. 

A bit of flavour of the Unity thanking the Crew can also go a long way to making them seem less like tyrannical corn syrup overlords, too.

## Changelog

Modifies the raise and drop to Blue Alert, as well as the drop to Green alert for better consistency.

:cl:
config: fucked with Alert Level messages a little.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
